### PR TITLE
Fix Character Library Ordering

### DIFF
--- a/AnimeCharacters/Pages/Characters.razor.cs
+++ b/AnimeCharacters/Pages/Characters.razor.cs
@@ -79,7 +79,7 @@ namespace AnimeCharacters.Pages
                                   LastProgressedAt = libraryEntry.ProgressedAt,
                                   VoiceActingRole = vaRoles[libraryEntry.Anime.MyAnimeListId].FirstOrDefault(),
                               })
-                              .OrderByDescending(item => item.LastProgressedAt.Value)
+                              .OrderByDescending(item => item.LastProgressedAt ?? System.DateTimeOffset.MinValue)
                               .ToList();
 
         }


### PR DESCRIPTION
If a library entry was added as "watching" but not started, it could cause a crash when ordering the animes.