### PR TITLE
Fix Library Updating & Ordering

### DIFF
--- a/Kitsu/Controllers/LibraryEventsController.cs
+++ b/Kitsu/Controllers/LibraryEventsController.cs
@@ -66,14 +66,14 @@ namespace Kitsu.Controllers
 
                     totalEntries++;
 
-                    if (entry.Id <= lastFetchedId)
-                    {
-                        return (mostRecentId, rtn);
-                    }
-
                     if (entry.Id > mostRecentId)
                     {
                         mostRecentId = entry.Id.Value;
+                    }
+
+                    if (entry.Id <= lastFetchedId)
+                    {
+                        return (mostRecentId, rtn);
                     }
 
                     var includedLibraryData = result.Included


### PR DESCRIPTION
This fixes two bugs:
 - Updating the library using the `library-events` endpoint
 - Re-ordering the library is now handled in the Filter view rather than when saving to the Dictionary (which is technically unordered)