### PR TITLE
Better library refresh

### DIFF
--- a/AnimeCharacters.sln
+++ b/AnimeCharacters.sln
@@ -7,6 +7,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AnimeCharacters", "AnimeCha
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Kitsu", "Kitsu\Kitsu.csproj", "{9F1E8B25-B9BF-4EBC-956F-65899CCF480A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Kitsu.Tests", "Kitsu.Tests\Kitsu.Tests.csproj", "{4D8A2CCF-0E0C-4C37-9CB6-B49E960BBD64}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{E90B4538-B291-4ECF-AAAA-2F8FFB298ECB}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,9 +25,16 @@ Global
 		{9F1E8B25-B9BF-4EBC-956F-65899CCF480A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9F1E8B25-B9BF-4EBC-956F-65899CCF480A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9F1E8B25-B9BF-4EBC-956F-65899CCF480A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4D8A2CCF-0E0C-4C37-9CB6-B49E960BBD64}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4D8A2CCF-0E0C-4C37-9CB6-B49E960BBD64}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4D8A2CCF-0E0C-4C37-9CB6-B49E960BBD64}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4D8A2CCF-0E0C-4C37-9CB6-B49E960BBD64}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{4D8A2CCF-0E0C-4C37-9CB6-B49E960BBD64} = {E90B4538-B291-4ECF-AAAA-2F8FFB298ECB}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {C2EE115D-FA84-4F5E-8BE3-D89FF829C696}

--- a/AnimeCharacters/Pages/Animes.razor
+++ b/AnimeCharacters/Pages/Animes.razor
@@ -29,7 +29,7 @@
                         }
                         else
                         {
-                            <div style="margin-top: 2px;" @onclick="() => _FetchLibraries(false)">
+                            <div style="margin-top: 2px;" @onclick="() => _FetchLibraries(true)">
                                 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" class="bi bi-arrow-counterclockwise" viewBox="0 0 16 16">
                                     <path fill-rule="evenodd" d="M8 3a5 5 0 1 1-4.546 2.914.5.5 0 0 0-.908-.417A6 6 0 1 0 8 2v1z" />
                                     <path d="M8 4.466V.534a.25.25 0 0 0-.41-.192L5.23 2.308a.25.25 0 0 0 0 .384l2.36 1.966A.25.25 0 0 0 8 4.466z" />

--- a/AnimeCharacters/Pages/Animes.razor
+++ b/AnimeCharacters/Pages/Animes.razor
@@ -29,7 +29,7 @@
                         }
                         else
                         {
-                            <div style="margin-top: 2px;" @onclick="() => _FetchLibraries(true)">
+                            <div style="margin-top: 2px;" @onclick="() => _FetchLibraries(false)">
                                 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" class="bi bi-arrow-counterclockwise" viewBox="0 0 16 16">
                                     <path fill-rule="evenodd" d="M8 3a5 5 0 1 1-4.546 2.914.5.5 0 0 0-.908-.417A6 6 0 1 0 8 2v1z" />
                                     <path d="M8 4.466V.534a.25.25 0 0 0-.41-.192L5.23 2.308a.25.25 0 0 0 0 .384l2.36 1.966A.25.25 0 0 0 8 4.466z" />

--- a/AnimeCharacters/Pages/Animes.razor.cs
+++ b/AnimeCharacters/Pages/Animes.razor.cs
@@ -136,6 +136,32 @@ namespace AnimeCharacters.Pages
             }
         }
 
+        async Task _FetchAnimeIds(int[] ids)
+        {
+            try
+            {
+                var updatedLibraries =
+                    (await _kitsuClient.UserLibraries.GetLibraryCollectionByIdsAsync
+                        (CurrentUser.Id,
+                        ids,
+                        LibraryType.Anime,
+                        LibraryStatus.Current | LibraryStatus.Completed))
+                    .ToDictionary(lib => lib.Id);
+
+                var addedLibraries = 
+
+                await DatabaseProvider.SetLibrariesAsync(_LibraryEntries.Values.ToList());
+                await _SetLastFetchedId();
+                return;
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"ERROR in _FetchAllUserAnime(): {ex.Message}");
+                Console.WriteLine($" STACKTRACE: {ex.StackTrace}");
+                await _EventAggregator.PublishAsync(new Events.SnackbarEvent("Error updating library. Please refresh page."));
+            }
+        }
+
         async Task _UpdateUserAnime()
         {
             void updateLibraryEntry(LibraryEntrySlim libraryEntrySlim)

--- a/AnimeCharacters/Pages/Animes.razor.cs
+++ b/AnimeCharacters/Pages/Animes.razor.cs
@@ -21,7 +21,7 @@ namespace AnimeCharacters.Pages
             1;
 #endif
 
-        const int _CACHE_REFRESH_TIME_FORCE_REFRESH_DAYS = 5;
+        const int _CACHE_REFRESH_TIME_FORCE_REFRESH_DAYS = 10;
 
         readonly KitsuClient _kitsuClient = new();
 

--- a/Kitsu.Tests/Helpers/EnumerableExtensions.cs
+++ b/Kitsu.Tests/Helpers/EnumerableExtensions.cs
@@ -1,0 +1,68 @@
+using Kitsu.Helpers;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+
+namespace Kitsu.Tests.Helpers
+{
+    [TestClass]
+    public class EnumerableExtensions
+    {
+        [TestMethod]
+        public void TestGetDelta()
+        {
+            var oldItem1 = new DeltaTest(1, "1");
+            var oldItem2 = new DeltaTest(2, "2");
+            var oldItem3 = new DeltaTest(3, "3");
+            var oldItem4 = new DeltaTest(4, "Four");
+            var newItem3 = new DeltaTest(3, "Three");
+            var newItem4 = new DeltaTest(4, "Four");
+            var newItem5 = new DeltaTest(5, "Five");
+            var oldList = new List<DeltaTest> { oldItem1, oldItem2, oldItem3, oldItem4 };
+            var newList = new List<DeltaTest> { newItem3, newItem4, newItem5 };
+
+            var expectedAddedItems = new List<DeltaTest> { newItem5 };
+            var expectedUpdatedItems = new List<DeltaTest> { newItem3 };
+            var expectedRemovedItems = new List<DeltaTest> { oldItem1, oldItem2 };
+
+            var delta = oldList.GetDelta(newList, l => l.Id, DeltaTestComparer.Default);
+
+            CollectionAssert.AreEquivalent(expectedAddedItems, delta.Added.ToList());
+            CollectionAssert.AreEquivalent(expectedUpdatedItems, delta.Updated.ToList());
+            CollectionAssert.AreEquivalent(expectedRemovedItems, delta.Deleted.ToList());
+        }
+
+        class DeltaTest
+        {
+            public DeltaTest() { }
+            public DeltaTest(int id, string data)
+            {
+                Id = id;
+                Data = data;
+            }
+
+            public int Id { get; set; }
+            public string Data { get; set; }
+        }
+
+        class DeltaTestComparer : IEqualityComparer<DeltaTest>
+        {
+            internal static DeltaTestComparer Default { get; } = new DeltaTestComparer();
+
+            public bool Equals(DeltaTest x, DeltaTest y)
+            {
+                if (x == null && y == null) { return true; }
+                if (x == null || y == null) { return false; }
+
+                return
+                    x.Id == y.Id &&
+                    x.Data == y.Data;
+            }
+
+            public int GetHashCode([DisallowNull] DeltaTest obj) =>
+                HashCode.Combine(obj.Id, obj.Data);
+        }
+    }
+}

--- a/Kitsu.Tests/Kitsu.Tests.csproj
+++ b/Kitsu.Tests/Kitsu.Tests.csproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.3" />
+    <PackageReference Include="coverlet.collector" Version="3.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Kitsu\Kitsu.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Kitsu/Comparers/LibraryComparer.cs
+++ b/Kitsu/Comparers/LibraryComparer.cs
@@ -1,0 +1,45 @@
+﻿using Kitsu.Models;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Kitsu.Comparers
+{
+    public class LibraryComparer : IEqualityComparer<LibraryEntry>
+    {
+        public static LibraryComparer Default { get; } = new LibraryComparer();
+
+        static IEqualityComparer<Anime> _AnimeComparer = ProjectionEqualityComparer.Create<Anime, string>(a => a.KitsuId);
+
+        public bool Equals(LibraryEntry x, LibraryEntry y) =>
+            y != null &&
+            x.Id == y.Id &&
+            x.Type == y.Type &&
+            x.Status == y.Status &&
+            x.MangaId == y.MangaId &&
+            x.IsReconsuming == y.IsReconsuming &&
+            EqualityComparer<DateTimeOffset?>.Default.Equals(x.StartedAt, y.StartedAt) &&
+            EqualityComparer<DateTimeOffset?>.Default.Equals(x.FinishedAt, y.FinishedAt) &&
+            EqualityComparer<DateTimeOffset?>.Default.Equals(x.ProgressedAt, y.ProgressedAt) &&
+            x.Progress == y.Progress &&
+            x.AnimeId == y.AnimeId &&
+            _AnimeComparer.Equals(x.Anime, y.Anime);
+
+        public int GetHashCode([DisallowNull] LibraryEntry obj)
+        {
+            HashCode hash = new();
+            hash.Add(obj.Id);
+            hash.Add(obj.Type);
+            hash.Add(obj.Status);
+            hash.Add(obj.MangaId);
+            hash.Add(obj.IsReconsuming);
+            hash.Add(obj.StartedAt);
+            hash.Add(obj.FinishedAt);
+            hash.Add(obj.ProgressedAt);
+            hash.Add(obj.Progress);
+            hash.Add(obj.AnimeId);
+            hash.Add(obj.Anime);
+            return hash.ToHashCode();
+        }
+    }
+}

--- a/Kitsu/Comparers/ProjectionComparer.cs
+++ b/Kitsu/Comparers/ProjectionComparer.cs
@@ -1,0 +1,138 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Kitsu.Comparers
+{
+
+    /// <summary>
+    /// Non-generic class to produce instances of the generic class,
+    /// optionally using type inference.
+    /// </summary>
+    public static class ProjectionEqualityComparer
+    {
+        /// <summary>
+        /// Creates an instance of ProjectionEqualityComparer using the specified projection.
+        /// </summary>
+        /// <typeparam name="TSource">Type parameter for the elements to be compared</typeparam>
+        /// <typeparam name="TKey">Type parameter for the keys to be compared,
+        /// after being projected from the elements</typeparam>
+        /// <param name="projection">Projection to use when determining the key of an element</param>
+        /// <returns>A comparer which will compare elements by projecting 
+        /// each element to its key, and comparing keys</returns>
+        public static ProjectionEqualityComparer<TSource, TKey> Create<TSource, TKey>(Func<TSource, TKey> projection)
+        {
+            return new ProjectionEqualityComparer<TSource, TKey>(projection);
+        }
+
+        /// <summary>
+        /// Creates an instance of ProjectionEqualityComparer using the specified projection.
+        /// The ignored parameter is solely present to aid type inference.
+        /// </summary>
+        /// <typeparam name="TSource">Type parameter for the elements to be compared</typeparam>
+        /// <typeparam name="TKey">Type parameter for the keys to be compared,
+        /// after being projected from the elements</typeparam>
+        /// <param name="ignored">Value is ignored - type may be used by type inference</param>
+        /// <param name="projection">Projection to use when determining the key of an element</param>
+        /// <returns>A comparer which will compare elements by projecting
+        /// each element to its key, and comparing keys</returns>
+        public static ProjectionEqualityComparer<TSource, TKey> Create<TSource, TKey>
+            (TSource ignored,
+             Func<TSource, TKey> projection)
+        {
+            return new ProjectionEqualityComparer<TSource, TKey>(projection);
+        }
+
+    }
+
+    /// <summary>
+    /// Class generic in the source only to produce instances of the 
+    /// doubly generic class, optionally using type inference.
+    /// </summary>
+    public static class ProjectionEqualityComparer<TSource>
+    {
+        /// <summary>
+        /// Creates an instance of ProjectionEqualityComparer using the specified projection.
+        /// </summary>
+        /// <typeparam name="TKey">Type parameter for the keys to be compared,
+        /// after being projected from the elements</typeparam>
+        /// <param name="projection">Projection to use when determining the key of an element</param>
+        /// <returns>A comparer which will compare elements by projecting each element to its key,
+        /// and comparing keys</returns>        
+        public static ProjectionEqualityComparer<TSource, TKey> Create<TKey>(Func<TSource, TKey> projection)
+        {
+            return new ProjectionEqualityComparer<TSource, TKey>(projection);
+        }
+    }
+
+    /// <summary>
+    /// Comparer which projects each element of the comparison to a key, and then compares
+    /// those keys using the specified (or default) comparer for the key type.
+    /// </summary>
+    /// <typeparam name="TSource">Type of elements which this comparer 
+    /// will be asked to compare</typeparam>
+    /// <typeparam name="TKey">Type of the key projected
+    /// from the element</typeparam>
+    public class ProjectionEqualityComparer<TSource, TKey> : IEqualityComparer<TSource>
+    {
+        readonly Func<TSource, TKey> projection;
+        readonly IEqualityComparer<TKey> comparer;
+
+        /// <summary>
+        /// Creates a new instance using the specified projection, which must not be null.
+        /// The default comparer for the projected type is used.
+        /// </summary>
+        /// <param name="projection">Projection to use during comparisons</param>
+        public ProjectionEqualityComparer(Func<TSource, TKey> projection)
+            : this(projection, null)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance using the specified projection, which must not be null.
+        /// </summary>
+        /// <param name="projection">Projection to use during comparisons</param>
+        /// <param name="comparer">The comparer to use on the keys. May be null, in
+        /// which case the default comparer will be used.</param>
+        public ProjectionEqualityComparer(Func<TSource, TKey> projection, IEqualityComparer<TKey> comparer)
+        {
+            if (projection == null)
+            {
+                throw new ArgumentNullException("projection");
+            }
+            this.comparer = comparer ?? EqualityComparer<TKey>.Default;
+            this.projection = projection;
+        }
+
+        /// <summary>
+        /// Compares the two specified values for equality by applying the projection
+        /// to each value and then using the equality comparer on the resulting keys. Null
+        /// references are never passed to the projection.
+        /// </summary>
+        public bool Equals(TSource x, TSource y)
+        {
+            if (x == null && y == null)
+            {
+                return true;
+            }
+            if (x == null || y == null)
+            {
+                return false;
+            }
+            return comparer.Equals(projection(x), projection(y));
+        }
+
+        /// <summary>
+        /// Produces a hash code for the given value by projecting it and
+        /// then asking the equality comparer to find the hash code of
+        /// the resulting key.
+        /// </summary>
+        public int GetHashCode(TSource obj)
+        {
+            if (obj == null)
+            {
+                throw new ArgumentNullException("obj");
+            }
+            return comparer.GetHashCode(projection(obj));
+        }
+    }
+}

--- a/Kitsu/Controllers/LibraryController.cs
+++ b/Kitsu/Controllers/LibraryController.cs
@@ -91,7 +91,7 @@ namespace Kitsu.Controllers
             return rtn;
         }
 
-        public async Task<List<LibraryEntry>> GetLibraryCollectionByIdsAsync(int userId, int[] ids, LibraryType type = LibraryType.All, LibraryStatus status = LibraryStatus.All)
+        public async Task<List<LibraryEntry>> GetLibraryCollectionByIdsAsync(int userId, long[] ids, LibraryType type = LibraryType.All, LibraryStatus status = LibraryStatus.All)
         {
             var rtn = new List<LibraryEntry>();
 

--- a/Kitsu/Controllers/LibraryController.cs
+++ b/Kitsu/Controllers/LibraryController.cs
@@ -90,6 +90,7 @@ namespace Kitsu.Controllers
 
             return rtn;
         }
+
         public async Task<List<LibraryEntry>> GetLibraryCollectionByIdsAsync(int userId, int[] ids, LibraryType type = LibraryType.All, LibraryStatus status = LibraryStatus.All)
         {
             var rtn = new List<LibraryEntry>();

--- a/Kitsu/Helpers/ArrayExtensions.cs
+++ b/Kitsu/Helpers/ArrayExtensions.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Kitsu.Helpers
+{
+    public static class ArrayExtensions
+    {
+        public static T[] Slice<T>(this T[] source, int index, int length)
+        {
+            var maxLength = Math.Min(source.Length - index, length);
+            T[] slice = new T[maxLength];
+            Array.Copy(source, index, slice, 0, maxLength);
+            return slice;
+        }
+
+        public static IEnumerable<T[]> Chunk<T>(this T[] source, int chunkSize)
+        {
+            for (int i = 0; i < source.Length; i += chunkSize)
+            {
+                yield return source.Slice(i, chunkSize);
+            }
+        }
+    }
+}

--- a/Kitsu/Helpers/EnumerableExtensions.cs
+++ b/Kitsu/Helpers/EnumerableExtensions.cs
@@ -1,20 +1,32 @@
-﻿using System;
+﻿using Kitsu.Comparers;
+using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Kitsu.Helpers
 {
     public static class EnumerableExtensions
     {
 
-        public static (IEnumerable<TList> Added, IEnumerable<TList> Updated, IEnumerable<TList> Deleted) GetDelta<TList, TComparer>(IEnumerable<TList> list) =>
-            GetDelta(list, l => l);
+        public static (IEnumerable<TList> Added, IEnumerable<TList> Updated, IEnumerable<TList> Deleted) GetDelta<TList, TComparer>(this IEnumerable<TList> oldList, IEnumerable<TList> newList) =>
+            GetDelta(oldList, newList, l => l, EqualityComparer<TList>.Default);
 
-        public static (IEnumerable<TList> Added, IEnumerable<TList> Updated, IEnumerable<TList> Deleted) GetDelta<TList, TComparer>(IEnumerable<TList> list, Func<TList, TComparer> comparer)
+        public static (IEnumerable<TList> Added, IEnumerable<TList> Updated, IEnumerable<TList> Deleted) GetDelta<TList, TComparer>(this IEnumerable<TList> oldList, IEnumerable<TList> newList, Func<TList, TComparer> idFunc) =>
+            GetDelta(oldList, newList, idFunc, EqualityComparer<TList>.Default);
+
+        public static (IEnumerable<TList> Added, IEnumerable<TList> Updated, IEnumerable<TList> Deleted) GetDelta<TList, TComparer>(this IEnumerable<TList> oldList, IEnumerable<TList> newList, Func<TList, TComparer> idFunc, IEqualityComparer<TList> updatedComparer)
         {
+            var comparer = ProjectionEqualityComparer.Create(idFunc);
 
+            var addedItems = newList.Except(oldList, comparer);
+            var removedItems = oldList.Except(newList, comparer);
+
+            var oldDictionaryList = oldList.Except(removedItems);
+            var newDictionaryList = newList.Except(addedItems);
+
+            var updatedItems = newDictionaryList.Except(oldDictionaryList, updatedComparer);
+
+            return (addedItems, updatedItems, removedItems);
         }
     }
 }

--- a/Kitsu/Helpers/EnumerableExtensions.cs
+++ b/Kitsu/Helpers/EnumerableExtensions.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Kitsu.Helpers
+{
+    public static class EnumerableExtensions
+    {
+
+        public static (IEnumerable<TList> Added, IEnumerable<TList> Updated, IEnumerable<TList> Deleted) GetDelta<TList, TComparer>(IEnumerable<TList> list) =>
+            GetDelta(list, l => l);
+
+        public static (IEnumerable<TList> Added, IEnumerable<TList> Updated, IEnumerable<TList> Deleted) GetDelta<TList, TComparer>(IEnumerable<TList> list, Func<TList, TComparer> comparer)
+        {
+
+        }
+    }
+}


### PR DESCRIPTION
The full library refresh whenever a new item was added could have taken a long time if the user has a large library. We now only find the ID of the newest items to fetch as to not hit the server too much.

Tests were also added.