### PR TITLE
chore: fix some bugs

### DIFF
--- a/AnimeCharacters/Components/VoiceActorTile.razor
+++ b/AnimeCharacters/Components/VoiceActorTile.razor
@@ -3,6 +3,8 @@
         <div class="col" @onclick="_OnAnimeClicked">
             <img src="@(CharacterAnime?.AnimeImageUrl ?? "#")" />
         </div>
+    </div>
+    <div class="row">
         <div class="col" @onclick="_OnCharacterClicked">
             <img src="@(CharacterAnime?.VoiceActingRole?.Image?.GetOptimalImage() ?? "#")" />
         </div>
@@ -11,6 +13,8 @@
         <div class="col" @onclick="_OnAnimeClicked">
             <div class="text-md-center text-primary">@(CharacterAnime?.VoiceActingRole?.Media?.FirstOrDefault()?.Title?.UserPreferred ?? "Loading...")</div>
         </div>
+    </div>
+    <div class="row">
         <div class="col" @onclick="_OnCharacterClicked">
             <div class="text-md-center text-secondary">@(CharacterAnime?.VoiceActingRole?.Name?.Full ?? "Loading...")</div>
         </div>

--- a/AnimeCharacters/Shared/NavMenu.razor
+++ b/AnimeCharacters/Shared/NavMenu.razor
@@ -6,9 +6,9 @@
 <nav class="navbar navbar-expand-sm navbar-light bg-light">
     @if (PageStateManager.CanGoBack)
     {
-        <div class="nav-item" style="display: flex; align-items: center;">
-            <a class="nav-link" @onclick="_GoBack">
-                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-arrow-left" viewBox="0 0 16 16">
+        <div class="nav-item" style="display: flex; align-items: center;" @onclick="_GoBack">
+            <a class="nav-link">
+                <svg style="display: flex; align-items: center" xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" class="bi bi-arrow-left" viewBox="0 0 16 16">
                     <path fill-rule="evenodd" d="M15 8a.5.5 0 0 0-.5-.5H2.707l3.147-3.146a.5.5 0 1 0-.708-.708l-4 4a.5.5 0 0 0 0 .708l4 4a.5.5 0 0 0 .708-.708L2.707 8.5H14.5A.5.5 0 0 0 15 8z" />
                 </svg>
             </a>


### PR DESCRIPTION
This fixes/improves the following:

 - Fixes an issue when viewing voice actors/characters the names of the characters or anime might appear next to each other instead of on top of each other
 - Increases and centers vertically the virtual back button
 - Prevents the library refresh from having multiple instances happen concurrently
 - When clicking the manual refresh button, we will do a shallow refresh first. If pressed within 15 seconds after the shallow refresh finishes, then we'll do a full refresh.