### PR TITLE
Collapse watching headers

### DIFF
--- a/AnimeCharacters/Pages/Animes.razor
+++ b/AnimeCharacters/Pages/Animes.razor
@@ -51,31 +51,27 @@
     {
         if (FilteredLibraryEntries.Any())
         {
-            <h4>Currently Watching</h4>
-            <hr />
-            <div class="row">
-                @foreach (var librayEntry in FilteredLibraryEntries?.Where(l => l.Status == Kitsu.Controllers.LibraryStatus.Current) ?? new List<Kitsu.Models.LibraryEntry>())
+            @foreach (var header in headerStates)
+            {
+                <h4 @onclick="() => ToggleHeaderState(header.Title)">
+                    @header.Title
+                    <button>@(header.IsCollapsed ? "Expand" : "Collapse")</button>
+                </h4>
+                <hr />
+                @if (!header.IsCollapsed)
                 {
-                    <div class="col">
-                        <div class="item-container" @onclick="() => _Anime_OnClicked(librayEntry)">
-                            <AnimeCharacters.Components.AnimeTile Anime="@librayEntry.Anime" />
-                        </div>
+                    <div class="row">
+                        @foreach (var librayEntry in header.Content)
+                        {
+                            <div class="col">
+                                <div class="item-container" @onclick="() => _Anime_OnClicked(librayEntry)">
+                                    <AnimeCharacters.Components.AnimeTile Anime="@librayEntry.Anime" />
+                                </div>
+                            </div>
+                        }
                     </div>
                 }
-            </div>
-
-            <h4>Completed</h4>
-            <hr />
-            <div class="row">
-                @foreach (var librayEntry in FilteredLibraryEntries?.Where(l => l.Status == Kitsu.Controllers.LibraryStatus.Completed) ?? new List<Kitsu.Models.LibraryEntry>())
-                {
-                    <div class="col">
-                        <div class="item-container" @onclick="() => _Anime_OnClicked(librayEntry)">
-                            <AnimeCharacters.Components.AnimeTile Anime="@librayEntry.Anime" />
-                        </div>
-                    </div>
-                }
-            </div>
+            }
         } else
         {
             <div class="d-flex justify-content-center">

--- a/AnimeCharacters/Pages/Animes.razor
+++ b/AnimeCharacters/Pages/Animes.razor
@@ -1,5 +1,8 @@
 ﻿@page "/animes"
 @inherits BasePage
+@using Kitsu.Models
+
+<link href="css/animes.css" rel="stylesheet" />
 
 <div class="content">
     <div class="row">
@@ -25,7 +28,7 @@
                     <div class="col-auto d-flex align-items-center" style="min-width: 0px;">
                         @if (IsBusy)
                         {
-                            <MatProgressCircle Indeterminate="true" Size="MatProgressCircle.Small" />
+                            <MatProgressCircle Indeterminate="true" Size="MatProgressCircleSize.Small" />
                         }
                         else
                         {
@@ -53,32 +56,38 @@
         {
             @foreach (var header in headerStates)
             {
-                <h4 @onclick="() => ToggleHeaderState(header.Title)">
-                    @header.Title
-                    <button>@(header.IsCollapsed ? "Expand" : "Collapse")</button>
-                </h4>
-                <hr />
-                @if (!header.IsCollapsed)
-                {
+                <div class="anime-header" @onclick="() => ToggleHeaderState(header.Title)">
+                    <div class="anime-header-title">
+                        <svg class="collapse-icon @(header.IsCollapsed ? "collapsed" : "")" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor">
+                            <path d="M7.646 4.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1-.708.708L8 5.707l-5.646 5.647a.5.5 0 0 1-.708-.708l6-6z"/>
+                        </svg>
+                        @header.Title
+                        <span class="anime-count">(@(header.Content?.Count ?? 0))</span>
+                    </div>
+                </div>
+                <div class="anime-content @(header.IsCollapsed ? "collapsed" : "expanded")">
                     <div class="row">
-                        @foreach (var librayEntry in header.Content)
+                        @foreach (var libraryEntry in header.Content ?? new List<LibraryEntry>())
                         {
                             <div class="col">
-                                <div class="item-container" @onclick="() => _Anime_OnClicked(librayEntry)">
-                                    <AnimeCharacters.Components.AnimeTile Anime="@librayEntry.Anime" />
+                                <div class="item-container" @onclick="() => _Anime_OnClicked(libraryEntry)">
+                                    <AnimeCharacters.Components.AnimeTile Anime="@libraryEntry.Anime" />
                                 </div>
                             </div>
                         }
                     </div>
-                }
+                </div>
             }
-        } else
+        }
+        else
         {
             <div class="d-flex justify-content-center">
                 <h5 class="text-muted">No animes found</h5>
             </div>
         }
-    } else {
+    }
+    else
+    {
         <div class="d-flex justify-content-center">
             <div class="control">
                 <MatProgressCircle Indeterminate="true" Size="MatProgressCircleSize.Medium" />

--- a/AnimeCharacters/Pages/Animes.razor
+++ b/AnimeCharacters/Pages/Animes.razor
@@ -21,11 +21,11 @@
                             @:You currently have @(_LibraryEntries.Count) animes in your library.
                         }
                     </div>
-                
+                 
                     <div class="col-auto d-flex align-items-center" style="min-width: 0px;">
                         @if (IsBusy)
                         {
-                            <MatProgressCircle Indeterminate="true" Size="MatProgressCircleSize.Small" />
+                            <MatProgressCircle Indeterminate="true" Size="MatProgressCircle.Small" />
                         }
                         else
                         {

--- a/AnimeCharacters/Pages/Animes.razor.cs
+++ b/AnimeCharacters/Pages/Animes.razor.cs
@@ -1,4 +1,4 @@
-﻿using AnimeCharacters.Helpers;
+using AnimeCharacters.Helpers;
 using Kitsu;
 using Kitsu.Comparers;
 using Kitsu.Controllers;
@@ -32,7 +32,7 @@ namespace AnimeCharacters.Pages
 
         DateTime? _lastShallowRefresh = null;
 
-        Dictionary<long, LibraryEntry> _LibraryEntries { get; set; }
+        Dictionary<long, LibraryEntry> _LibraryEntries { get; set; } = new Dictionary<long, LibraryEntry>();
 
         public User CurrentUser { get; set; }
 
@@ -126,7 +126,7 @@ namespace AnimeCharacters.Pages
 
         protected void _Anime_OnClicked(LibraryEntry libraryEntry)
         {
-            if (libraryEntry?.Anime == null) { return; }
+            if (libraryEntry?.Anime == null || _LibraryEntries == null) { return; }
 
             NavigationManager.NavigateTo($"/animes/{libraryEntry.Anime.KitsuId}");
         }

--- a/AnimeCharacters/Pages/Animes.razor.cs
+++ b/AnimeCharacters/Pages/Animes.razor.cs
@@ -60,6 +60,22 @@ namespace AnimeCharacters.Pages
             }
         }
 
+        // List of header states
+        private List<HeaderState> headerStates = new List<HeaderState>();
+
+        // List of header names
+        private List<string> headerNames = new List<string> { "Currently Watching", "Completed" };
+
+        // Method to toggle the collapsed/expanded state of a header
+        private void ToggleHeaderState(string headerName)
+        {
+            var header = headerStates.FirstOrDefault(h => h.Title == headerName);
+            if (header != null)
+            {
+                header.IsCollapsed = !header.IsCollapsed;
+            }
+        }
+
         protected override async Task OnInitializedAsync()
         {
             CurrentUser = await DatabaseProvider.GetUserAsync();
@@ -70,6 +86,14 @@ namespace AnimeCharacters.Pages
                 NavigationManager.NavigateTo("/");
                 return;
             }
+
+            // Initialize header states
+            headerStates = headerNames.Select(name => new HeaderState
+            {
+                Title = name,
+                IsCollapsed = false,
+                Content = FilteredLibraryEntries?.Where(l => l.Status == (name == "Currently Watching" ? Kitsu.Controllers.LibraryStatus.Current : Kitsu.Controllers.LibraryStatus.Completed)).ToList()
+            }).ToList();
 
             await base.OnInitializedAsync();
         }
@@ -340,7 +364,7 @@ namespace AnimeCharacters.Pages
             if (!string.IsNullOrWhiteSpace(anime.RomanjiTitle))
             {
                 var romanjiTitleSplit = anime.Title.ToLower().Split(' ');
-                if (romanjiTitleSplit.Any(t => t.StartsWith(lowerFilter)))
+                if (romanjiTitleSplit.Any(t => t.StartsWith(lowerFilter))
                 {
                     return true;
                 }
@@ -349,7 +373,7 @@ namespace AnimeCharacters.Pages
             if (!string.IsNullOrWhiteSpace(anime.EnglishTitle))
             {
                 var englishTitleSplit = anime.EnglishTitle.ToLower().Split(' ');
-                if (englishTitleSplit.Any(t => t.StartsWith(lowerFilter)))
+                if (englishTitleSplit.Any(t => t.StartsWith(lowerFilter))
                 {
                     return true;
                 }
@@ -368,6 +392,14 @@ namespace AnimeCharacters.Pages
                 await DatabaseProvider.SetLastFetchedIdAsync(lastEventId);
                 await DatabaseProvider.SetLastFetchedDateAsync(DateTimeOffset.Now);
             }
+        }
+
+        // Class to represent the state of each header
+        public class HeaderState
+        {
+            public string Title { get; set; }
+            public bool IsCollapsed { get; set; }
+            public List<LibraryEntry> Content { get; set; }
         }
     }
 }

--- a/AnimeCharacters/wwwroot/css/animes.css
+++ b/AnimeCharacters/wwwroot/css/animes.css
@@ -1,0 +1,92 @@
+.anime-header {
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 12px 16px;
+    background-color: #f8f9fa;
+    border-radius: 6px;
+    margin-bottom: 8px;
+    -webkit-user-select: none;
+    user-select: none;
+    transition: background-color 0.2s ease, transform 0.1s ease;
+}
+
+.anime-header:hover {
+    background-color: #e9ecef;
+}
+
+.anime-header:active {
+    transform: scale(0.99);
+}
+
+.anime-header-title {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    font-size: 1.5rem;
+    margin: 0;
+    color: #343a40;
+}
+
+.anime-count {
+    font-size: 1rem;
+    color: #6c757d;
+    margin-left: 8px;
+    font-weight: normal;
+}
+
+.anime-content {
+    overflow: hidden;
+    transition: max-height 0.3s cubic-bezier(0.4, 0, 0.2, 1),
+                opacity 0.3s cubic-bezier(0.4, 0, 0.2, 1),
+                margin 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+    will-change: max-height, opacity;
+    opacity: 1;
+}
+
+.collapse-icon {
+    transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+    width: 20px;
+    height: 20px;
+    will-change: transform;
+    flex-shrink: 0;
+    color: #6c757d;
+}
+
+.collapse-icon.collapsed {
+    transform: rotate(-90deg);
+}
+
+.anime-content.collapsed {
+    max-height: 0;
+    margin: 0;
+    padding: 0;
+    opacity: 0;
+}
+
+.anime-content.expanded {
+    max-height: 10000px;
+    margin-bottom: 24px;
+    opacity: 1;
+}
+
+.item-container {
+    margin-bottom: 16px;
+    transition: transform 0.2s ease;
+    cursor: pointer;
+}
+
+.item-container:hover {
+    transform: translateY(-2px);
+}
+
+.row {
+    margin-right: -8px;
+    margin-left: -8px;
+}
+
+.col {
+    padding-right: 8px;
+    padding-left: 8px;
+}


### PR DESCRIPTION
Fixes #17

Add functionality to collapse or expand the 'Currently Watching' and 'Completed' headers on the main page.

* Add a list of `HeaderState` to track the headers in `AnimeCharacters/Pages/Animes.razor.cs`.
* Add a method `ToggleHeaderState` to toggle the collapsed/expanded state of a header in `AnimeCharacters/Pages/Animes.razor.cs`.
* Add a list of header names to be used in the loop in `AnimeCharacters/Pages/Animes.razor.cs`.
* Create a class `HeaderState` that contains the stateful information of each header, including the title, content, and if it is collapsed or not in `AnimeCharacters/Pages/Animes.razor.cs`.
* Replace the static headers with a loop from the headers that uses the 'contentFilter' to determine what is shown as the content of that header in `AnimeCharacters/Pages/Animes.razor`.
* Wrap the content under each header in a conditional block that only renders when the corresponding state variable indicates the header is expanded in `AnimeCharacters/Pages/Animes.razor`.
* Add a button or clickable element next to each header to toggle the collapsed/expanded state in `AnimeCharacters/Pages/Animes.razor`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/nolanblew/AnimeCharacters/issues/17?shareId=f3f3e3fe-16b8-4323-9fc4-c020669c5086).