### PR TITLE
Fix character/VA filtering

### DIFF
--- a/AnimeCharacters/Pages/AnimeDetails.razor.cs
+++ b/AnimeCharacters/Pages/AnimeDetails.razor.cs
@@ -69,7 +69,26 @@ namespace AnimeCharacters.Pages
         async Task _LoadCharacters()
         {
             var media = await AnilistClient.Characters.GetMediaWithCharactersById(int.Parse(CurrentAnime.AnilistId));
-            CharactersList = media.Characters.OrderByDescending(c => c, CharacterByRoleComparer.Instance).ToList();
+
+            var characters = new List<AniListClient.Models.Character>();
+
+            foreach (var character in media.Characters)
+            {
+                if (character.VoiceActors?.Any() == true)
+                {
+                    foreach (var va in character.VoiceActors)
+                    {
+                        // clone character but only include the current voice actor
+                        characters.Add(character with { VoiceActors = new List<AniListClient.Models.VoiceActorSlim> { va } });
+                    }
+                }
+                else
+                {
+                    characters.Add(character);
+                }
+            }
+
+            CharactersList = characters;
         }
     }
 }

--- a/AnimeCharacters/Pages/Characters.razor.cs
+++ b/AnimeCharacters/Pages/Characters.razor.cs
@@ -69,14 +69,21 @@ namespace AnimeCharacters.Pages
 
         async Task _LoadCharacters()
         {
-            var vaRoles = new Dictionary<string, AniListClient.Models.Character>();
+            // Key by AniList anime id -> list of characters this VA voiced in that anime
+            var vaRoles = new Dictionary<string, List<AniListClient.Models.Character>>();
 
-            foreach (var person in CurrentPerson.Characters.Where(role => role.Media != null))
+            foreach (var character in CurrentPerson.Characters.Where(role => role.Media != null))
             {
-                foreach (var mediaItem in person.Media)
+                foreach (var mediaItem in character.Media)
                 {
-                    // TODO: Allow VAs to have multiple roles in the same anime
-                    vaRoles.TryAdd(mediaItem.Id.ToString(), person);
+                    if (!vaRoles.TryGetValue(mediaItem.Id.ToString(), out var list))
+                    {
+                        list = new List<AniListClient.Models.Character>();
+                        vaRoles[mediaItem.Id.ToString()] = list;
+                    }
+
+                    // Preserve order of characters as returned from the API
+                    list.Add(character);
                 }
             }
 
@@ -84,13 +91,13 @@ namespace AnimeCharacters.Pages
 
             MyCharactersList =
                 libraryEntries.Where(libraryEntry => !string.IsNullOrWhiteSpace(libraryEntry.Anime.AnilistId) && vaRoles.ContainsKey(libraryEntry.Anime.AnilistId))
-                              .Select(libraryEntry => new CharacterAnimeModel
+                              .SelectMany(libraryEntry => vaRoles[libraryEntry.Anime.AnilistId].Select(character => new CharacterAnimeModel
                               {
                                   KitsuId = libraryEntry.Anime.KitsuId,
                                   AnimeImageUrl = libraryEntry.Anime.PosterImageUrl,
                                   LastProgressedAt = libraryEntry.ProgressedAt,
-                                  VoiceActingRole = vaRoles[libraryEntry.Anime.AnilistId],
-                              })
+                                  VoiceActingRole = character,
+                              }))
                               .OrderByDescending(item => item.LastProgressedAt ?? System.DateTimeOffset.MinValue)
                               .ToList();
 


### PR DESCRIPTION
## Summary
- allow multiple roles per anime on the VA characters screen
- expand characters with multiple voice actors on the anime details screen

## Testing
- `dotnet test --no-build --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_688105774aa0832c9b09488d07d1b183