### PR TITLE
Fix character tile layout and adjust mobile arrow spacing

### DIFF
--- a/AnimeCharacters/Pages/AnimeDetails.razor
+++ b/AnimeCharacters/Pages/AnimeDetails.razor
@@ -24,7 +24,7 @@
 <div class="row">
     @foreach (var character in CharactersList)
     {
-<div class="col">
+<div class="col-auto">
     <div class="item-container" @onclick="() => _Character_OnClicked(character)">
         <AnimeCharacters.Components.CharacterTile Character="@character" Language="@Language" />
     </div>

--- a/AnimeCharacters/Pages/Animes.razor
+++ b/AnimeCharacters/Pages/Animes.razor
@@ -69,7 +69,7 @@
                     <div class="row">
                         @foreach (var libraryEntry in header.Content ?? new List<LibraryEntry>())
                         {
-                            <div class="col">
+                            <div class="col-auto">
                                 <div class="item-container" @onclick="() => _Anime_OnClicked(libraryEntry)">
                                     <AnimeCharacters.Components.AnimeTile Anime="@libraryEntry.Anime" />
                                 </div>

--- a/AnimeCharacters/Pages/Characters.razor
+++ b/AnimeCharacters/Pages/Characters.razor
@@ -78,13 +78,11 @@
                             <button class="btn btn-link p-0 mt-2 va-show-more-btn" @onclick="ToggleMobileDetails">
                                 @if (_showMobileDetails)
                                 {
-                                    <span>Show Less</span>
-                                    <i class="oi oi-chevron-top ms-1"></i>
+                                    <span>Show Less</span> <i class="oi oi-chevron-top ms-1"></i>
                                 }
                                 else
                                 {
-                                    <span>Show More</span>
-                                    <i class="oi oi-chevron-bottom ms-1"></i>
+                                    <span>Show More</span> <i class="oi oi-chevron-bottom ms-1"></i>
                                 }
                             </button>
                         </div>
@@ -147,7 +145,7 @@
         <div class="row">
             @foreach (var characterAnime in MyCharactersList)
             {
-                <div class="col">
+                <div class="col-auto">
                     <div class="item-container">
                         <AnimeCharacters.Components.VoiceActorTile CharacterAnime="characterAnime" OnAnimeClicked="() => _OnAnimeClicked(characterAnime)" OnCharacterClicked="() => _OnCharacterClicked(characterAnime)" />
                     </div>
@@ -161,7 +159,7 @@
         <div class="row">
             @foreach (var characterAnime in NotMyCharactersList)
             {
-                <div class="col">
+                <div class="col-auto">
                     <div class="item-container">
                         <AnimeCharacters.Components.VoiceActorTile CharacterAnime="characterAnime" OnAnimeClicked="() => _OnAnimeClicked(characterAnime)" OnCharacterClicked="() => _OnCharacterClicked(characterAnime)" />
                     </div>

--- a/AnimeCharacters/wwwroot/css/animes.css
+++ b/AnimeCharacters/wwwroot/css/animes.css
@@ -90,3 +90,7 @@
     padding-right: 8px;
     padding-left: 8px;
 }
+.col-auto {
+    padding-right: 8px;
+    padding-left: 8px;
+}

--- a/AnimeCharacters/wwwroot/css/app.css
+++ b/AnimeCharacters/wwwroot/css/app.css
@@ -86,6 +86,10 @@ a, .btn-link {
     padding-left: 8px;
     padding-right: 8px;
 }
+.col-auto {
+    padding-left: 8px;
+    padding-right: 8px;
+}
 
 .item {
     flex-grow: 1;


### PR DESCRIPTION
## Summary
- keep leftover tiles aligned to the left by using `col-auto`
- add padding for `.col-auto` so spacing matches
- separate the expander arrow from the text on mobile

## Testing
- `dotnet test AnimeCharacters.sln --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_688131b27754832c8d8e1717aa7fbdcd