### PR TITLE
Use grid layout for tiles

### DIFF
--- a/AnimeCharacters/Pages/AnimeDetails.razor
+++ b/AnimeCharacters/Pages/AnimeDetails.razor
@@ -22,22 +22,22 @@
 
     @if (CharactersList?.Any() == true)
     {
-<div class="row">
-    @foreach (var character in CharactersList)
+        <div class="item-grid">
+            @foreach (var character in CharactersList)
+            {
+                <div class="item-container" @onclick="() => _Character_OnClicked(character)">
+                    <AnimeCharacters.Components.CharacterTile Character="@character" Language="@Language" />
+                </div>
+            }
+        </div>
+    }
+    else
     {
-<div class="col-auto">
-    <div class="item-container" @onclick="() => _Character_OnClicked(character)">
-        <AnimeCharacters.Components.CharacterTile Character="@character" Language="@Language" />
-    </div>
-</div>                }
-</div>
-}
-else
-{
-<div class="d-flex justify-content-center">
-    <div class="control">
-        <MatProgressCircle Indeterminate="true" Size="MatProgressCircleSize.Medium" />
-    </div>
-</div>}
+        <div class="d-flex justify-content-center">
+            <div class="control">
+                <MatProgressCircle Indeterminate="true" Size="MatProgressCircleSize.Medium" />
+            </div>
+        </div>
+    }
 
 </div>

--- a/AnimeCharacters/Pages/Animes.razor
+++ b/AnimeCharacters/Pages/Animes.razor
@@ -67,13 +67,11 @@
                     </div>
                 </div>
                 <div class="anime-content @(header.IsCollapsed ? "collapsed" : "expanded")">
-                    <div class="row">
+                    <div class="item-grid">
                         @foreach (var libraryEntry in header.Content ?? new List<LibraryEntry>())
                         {
-                            <div class="col-auto">
-                                <div class="item-container" @onclick="() => _Anime_OnClicked(libraryEntry)">
-                                    <AnimeCharacters.Components.AnimeTile Anime="@libraryEntry.Anime" />
-                                </div>
+                            <div class="item-container" @onclick="() => _Anime_OnClicked(libraryEntry)">
+                                <AnimeCharacters.Components.AnimeTile Anime="@libraryEntry.Anime" />
                             </div>
                         }
                     </div>

--- a/AnimeCharacters/Pages/Characters.razor
+++ b/AnimeCharacters/Pages/Characters.razor
@@ -142,13 +142,11 @@
 
     @if (MyCharactersList?.Any() == true)
     {
-        <div class="row">
+        <div class="item-grid">
             @foreach (var characterAnime in MyCharactersList)
             {
-                <div class="col-auto">
-                    <div class="item-container">
-                        <AnimeCharacters.Components.VoiceActorTile CharacterAnime="characterAnime" OnAnimeClicked="() => _OnAnimeClicked(characterAnime)" OnCharacterClicked="() => _OnCharacterClicked(characterAnime)" />
-                    </div>
+                <div class="item-container">
+                    <AnimeCharacters.Components.VoiceActorTile CharacterAnime="characterAnime" OnAnimeClicked="() => _OnAnimeClicked(characterAnime)" OnCharacterClicked="() => _OnCharacterClicked(characterAnime)" />
                 </div>
             }
         </div>
@@ -156,13 +154,11 @@
 
     @if (NotMyCharactersList?.Any() == true)
     {
-        <div class="row">
+        <div class="item-grid">
             @foreach (var characterAnime in NotMyCharactersList)
             {
-                <div class="col-auto">
-                    <div class="item-container">
-                        <AnimeCharacters.Components.VoiceActorTile CharacterAnime="characterAnime" OnAnimeClicked="() => _OnAnimeClicked(characterAnime)" OnCharacterClicked="() => _OnCharacterClicked(characterAnime)" />
-                    </div>
+                <div class="item-container">
+                    <AnimeCharacters.Components.VoiceActorTile CharacterAnime="characterAnime" OnAnimeClicked="() => _OnAnimeClicked(characterAnime)" OnCharacterClicked="() => _OnCharacterClicked(characterAnime)" />
                 </div>
             }
         </div>

--- a/AnimeCharacters/wwwroot/css/app.css
+++ b/AnimeCharacters/wwwroot/css/app.css
@@ -70,6 +70,18 @@ a, .btn-link {
     justify-content: safe center;
 }
 
+
+.item-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(115px, 1fr));
+    gap: 16px;
+    justify-items: center;
+}
+
+.item-grid .item-container {
+    margin-bottom: 0;
+}
+
 .item-container {
     display: flex;
     flex-flow: column;
@@ -77,8 +89,8 @@ a, .btn-link {
 }
 
 .item-container img {
-    width: 115px;
-    height: 165px;
+    width: 100%;
+    height: auto;
     border-radius: 4px;
 }
 
@@ -93,18 +105,17 @@ a, .btn-link {
 
 .item {
     flex-grow: 1;
-    max-width: 115px;
+    width: 100%;
     text-align: center;
 }
 
 @media screen and (max-width: 600px) {
-    .item-container img {
-        max-width: 90px;
-        height: 129px;
+    .item-grid {
+        grid-template-columns: repeat(auto-fill, minmax(90px, 1fr));
     }
 
-    .item {
-        width: 90px;
+    .item-container img {
+        max-width: 100%;
     }
 }
 


### PR DESCRIPTION
## Summary
- replace Bootstrap row/column layout with CSS grid for anime, character, and voice actor lists
- add reusable `.item-grid` CSS to distribute tiles evenly across rows and keep last row left-aligned
- adjust tile images to scale responsively

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a36f20a320832cbc1422a9fec5f6ab