### PR TITLE
Add build-time version generation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,11 @@ The solution can be opened in Visual Studio 2022 or VS Code with the C# extensio
 
 Note that merging to `main` will trigger a GitHub Action to build and deploy the application to production.
 
+## Versioning
+
+The application embeds a build-time version string in the format `yyyy-MM-bbbb` using the current UTC date and an incremental build number.
+Debug builds prepend the version with `dev-`.
+
 ## Architecture
 
 ### Project Structure

--- a/AnimeCharacters/AnimeCharacters.csproj
+++ b/AnimeCharacters/AnimeCharacters.csproj
@@ -1,24 +1,50 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
+<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <BuildNumberFile>$(BaseIntermediateOutputPath)build.number</BuildNumberFile>
+    <GeneratedVersionFile>$(BaseIntermediateOutputPath)VersionInfo.g.cs</GeneratedVersionFile>
+  </PropertyGroup>
+
+  <Target Name="GenerateVersionInfo" BeforeTargets="CoreCompile">
+    <Exec Command='LC_ALL=C python build_version.py "$(BuildNumberFile)"' WorkingDirectory="$(MSBuildProjectDirectory)" ConsoleToMSBuild="true">
+      <Output TaskParameter="ConsoleOutput" PropertyName="VersionCore" />
+    </Exec>
+    <PropertyGroup>
+      <_VersionPrefix Condition="'$(Configuration)' == 'Debug'">dev-</_VersionPrefix>
+      <VersionString>$(_VersionPrefix)$(VersionCore)</VersionString>
+    </PropertyGroup>
+    <ItemGroup>
+      <VersionFileLines Include="namespace AnimeCharacters%3B" />
+      <VersionFileLines Include="public static class VersionInfo" />
+      <VersionFileLines Include="{" />
+      <VersionFileLines Include="    public const string Version = &quot;$(VersionString)&quot;%3B" />
+      <VersionFileLines Include="}" />
+    </ItemGroup>
+    <WriteLinesToFile File="$(GeneratedVersionFile)" Lines="@(VersionFileLines)" Overwrite="true" />
+    <ItemGroup>
+      <Compile Include="$(GeneratedVersionFile)" />
+    </ItemGroup>
+  </Target>
+
   <ItemGroup>
-	  <PackageReference Include="Blazored.LocalStorage" Version="4.5.0" />
-	  <PackageReference Include="EventAggregator.Blazor" Version="2.0.0" />
-	  <PackageReference Include="Markdig" Version="0.31.0" />
-	  <PackageReference Include="MatBlazor" Version="2.10.0" />
-	  <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.7" />
-	  <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.7" PrivateAssets="all" />
-	  <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.7" />
-	  <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.7">
-		  <PrivateAssets>all</PrivateAssets>
-		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-	  </PackageReference>
-	  <PackageReference Include="Polly" Version="8.4.1" />
-	  <PackageReference Include="System.Net.Http.Json" Version="8.0.0" />
+    <PackageReference Include="Blazored.LocalStorage" Version="4.5.0" />
+    <PackageReference Include="EventAggregator.Blazor" Version="2.0.0" />
+    <PackageReference Include="Markdig" Version="0.31.0" />
+    <PackageReference Include="MatBlazor" Version="2.10.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.7" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.7">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Polly" Version="8.4.1" />
+    <PackageReference Include="System.Net.Http.Json" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/AnimeCharacters/Pages/ProfileSettings.razor.cs
+++ b/AnimeCharacters/Pages/ProfileSettings.razor.cs
@@ -43,24 +43,10 @@ namespace AnimeCharacters.Pages
             await _EventAggregator.PublishAsync(new Events.SnackbarEvent("Settings saved"));
         }
 
-        async Task GetAppVersionAsync()
+        Task GetAppVersionAsync()
         {
-            try
-            {
-                var registration = await JSRuntime.InvokeAsync<IJSObjectReference>("navigator.serviceWorker.getRegistration");
-                if (registration != null)
-                {
-                    var activeWorker = await registration.InvokeAsync<IJSObjectReference>("active");
-                    if (activeWorker != null)
-                    {
-                        AppVersion = "2.0.0"; // Default version, could be enhanced to get from service worker
-                    }
-                }
-            }
-            catch
-            {
-                AppVersion = "2.0.0";
-            }
+            AppVersion = VersionInfo.Version;
+            return Task.CompletedTask;
         }
 
         async Task CheckForUpdatesAsync()

--- a/AnimeCharacters/build_version.py
+++ b/AnimeCharacters/build_version.py
@@ -1,0 +1,10 @@
+import sys, datetime, pathlib
+
+path = pathlib.Path(sys.argv[1])
+try:
+    build = int(path.read_text())
+except Exception:
+    build = 0
+build += 1
+path.write_text(str(build))
+print(datetime.datetime.utcnow().strftime('%Y-%m') + '-' + f'{build:04d}')

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,11 @@ The solution can be opened in Visual Studio 2022 or VS Code with the C# extensio
 
 Note that merging to `main` will trigger a GitHub Action to build and deploy the application to production.
 
+## Versioning
+
+The build process generates a version string in the format `yyyy-MM-bbbb` based on the current UTC date and an incremental build number.
+Debug builds prepend the version with `dev-`.
+
 ## Architecture
 
 ### Project Structure

--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ Quickly find the characters that a Seyu (voice actor) has also played in other a
 
 Not much else is needed, and you can build on any platform that supports dotnet.
 
+## Versioning
+
+The application generates a version at build time using the format `yyyy-MM-bbbb` (UTC date and incremental build number).
+Debug builds are prefixed with `dev-`.
+
 # Contributing
 Contributions would be greatly appreciated. Feel free to create issues as well as forking the repo and creating PRs.
 If you wish to make some major contributions please create an issue and we can evauate making you a contributer.


### PR DESCRIPTION
## Summary
- generate version string `yyyy-MM-bbbb` at build time with Python helper
- display build version on profile settings page
- document new incremental build versioning

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a4240c19d8832cacd3c17cc79e2de9