### PR TITLE
Fix NRE by adding titles and poster image fallback sizes

### DIFF
--- a/Kitsu/Models/Anime.cs
+++ b/Kitsu/Models/Anime.cs
@@ -17,12 +17,17 @@ namespace Kitsu.Models
             MyAnimeListId = myAnimeListId;
             AnilistId = anilistId;
             Title = animeResponse.CanonicalTitle;
-            RomanjiTitle = animeResponse.Titles.EnJp;
-            EnglishTitle = animeResponse.Titles.En;
+            RomanjiTitle = animeResponse.Titles?.EnJp;
+            EnglishTitle = animeResponse.Titles?.En ?? animeResponse.Titles?.EnUs;
             KitsuSlug = animeResponse.Slug;
-            PosterImageUrl = animeResponse.PosterImage.Large.AbsoluteUri;
+            PosterImageUrl = GetPosterImageUrl(animeResponse.PosterImage, Title);
             YoutubeId = animeResponse.YoutubeVideoId;
             ShowType = animeResponse.ShowType.HasValue ? ParseAnimeType(animeResponse.ShowType.Value) : null;
+
+            if (string.IsNullOrWhiteSpace(RomanjiTitle) && string.IsNullOrWhiteSpace(EnglishTitle))
+            {
+                Console.WriteLine($"WARNING: Anime with Kitsu ID '{kitsuId}' is missing both EnJp and En/EnUs titles.");
+            }
         }
 
         public Anime(
@@ -77,6 +82,38 @@ namespace Kitsu.Models
             }
 
             return null;
+        }
+
+        private static string GetPosterImageUrl(Responses.UserLibraryGetRequest.PosterImage posterImage, string title)
+        {
+            var url = posterImage?.Large?.AbsoluteUri
+                ?? posterImage?.Medium?.AbsoluteUri
+                ?? posterImage?.Original?.AbsoluteUri
+                ?? posterImage?.Small?.AbsoluteUri;
+
+            if (!string.IsNullOrWhiteSpace(url))
+            {
+                return url;
+            }
+
+            return GeneratePlaceholderDataUri(title);
+        }
+
+        private static string GeneratePlaceholderDataUri(string title)
+        {
+            var initial = !string.IsNullOrWhiteSpace(title) ? title[0].ToString().ToUpperInvariant() : "?";
+            var svg = $@"<svg xmlns='http://www.w3.org/2000/svg' width='225' height='350'>
+  <defs>
+    <linearGradient id='grad' x1='0%' y1='0%' x2='100%' y2='100%'>
+      <stop offset='0%' style='stop-color:#4a4a4a;stop-opacity:1' />
+      <stop offset='100%' style='stop-color:#2a2a2a;stop-opacity:1' />
+    </linearGradient>
+  </defs>
+  <rect width='225' height='350' fill='url(#grad)' rx='4'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-family='Arial, sans-serif' font-size='80' font-weight='bold' fill='#888888'>{initial}</text>
+</svg>";
+            var base64 = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(svg));
+            return $"data:image/svg+xml;base64,{base64}";
         }
 
         public static AnimeType? ParseAnimeType(string animeType)


### PR DESCRIPTION
There was an error that would occur if the `Large` poster image was not found.

This both fixes this to allow fallback sizes, as well as allowing the `english_us` title that is rarely used in case the normal english one doesn't exist (this happened in Avatar).

It also shows a placeholder poster image when no poster images can be found.