### PR TITLE
Handle AniList character loading failures

### DIFF
--- a/AniListClient/Controllers/BaseController.cs
+++ b/AniListClient/Controllers/BaseController.cs
@@ -1,6 +1,7 @@
 ﻿using AniListClient.Queries;
 using GraphQL;
 using GraphQL.Client.Http;
+using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
@@ -64,7 +65,11 @@ namespace AniListClient.Controllers
                 {
                     result = await _graphQLHttpClient.SendQueryAsync<TBase>(request);
                 }
-                catch (HttpRequestException)
+                catch (GraphQLHttpRequestException ex)
+                {
+                    throw new InvalidOperationException(GetGraphQLHttpErrorMessage(ex), ex);
+                }
+                catch (HttpRequestException ex)
                 {
                     if (lastModel != null)
                     {
@@ -72,7 +77,17 @@ namespace AniListClient.Controllers
                         return lastModel;
                     }
 
-                    return default;
+                    throw new InvalidOperationException("Unable to reach AniList. The API may be unavailable right now.", ex);
+                }
+
+                if (result.Errors?.Length > 0)
+                {
+                    throw new InvalidOperationException(result.Errors[0].Message);
+                }
+
+                if (result.Data == null)
+                {
+                    throw new InvalidOperationException("AniList did not return any data.");
                 }
 
                 lastModel = conversionSelector(result.Data);
@@ -85,6 +100,30 @@ namespace AniListClient.Controllers
                     return lastModel;
                 }
             }
+        }
+
+        private static string GetGraphQLHttpErrorMessage(GraphQLHttpRequestException ex)
+        {
+            if (string.IsNullOrWhiteSpace(ex.Content))
+            {
+                return $"AniList returned HTTP {(int)ex.StatusCode}.";
+            }
+
+            try
+            {
+                var message = JObject.Parse(ex.Content)["errors"]?[0]?["message"]?.Value<string>();
+
+                if (!string.IsNullOrWhiteSpace(message))
+                {
+                    return message;
+                }
+            }
+            catch
+            {
+                // Fall back to the HTTP status below when the response body is not JSON.
+            }
+
+            return $"AniList returned HTTP {(int)ex.StatusCode}.";
         }
     }
 }

--- a/AnimeCharacters/AnimeCharacters.csproj
+++ b/AnimeCharacters/AnimeCharacters.csproj
@@ -54,15 +54,15 @@
     <PackageReference Include="EventAggregator.Blazor" Version="2.0.0" />
     <PackageReference Include="Markdig" Version="0.31.0" />
     <PackageReference Include="MatBlazor" Version="2.10.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.7" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.7" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.7" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.7">
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.26" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.26" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.26" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.26">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Polly" Version="8.4.1" />
-    <PackageReference Include="System.Net.Http.Json" Version="8.0.0" />
+    <PackageReference Include="Polly" Version="8.4.2" />
+    <PackageReference Include="System.Net.Http.Json" Version="8.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/AnimeCharacters/Pages/AnimeDetails.razor
+++ b/AnimeCharacters/Pages/AnimeDetails.razor
@@ -20,7 +20,21 @@
     <h3>Characters</h3>
     <hr />
 
-    @if (CharactersList?.Any() == true)
+    @if (IsLoadingCharacters)
+    {
+        <div class="d-flex justify-content-center">
+            <div class="control">
+                <MatProgressCircle Indeterminate="true" Size="MatProgressCircleSize.Medium" />
+            </div>
+        </div>
+    }
+    else if (!string.IsNullOrWhiteSpace(CharacterLoadError))
+    {
+        <div class="alert alert-warning" role="alert">
+            @CharacterLoadError
+        </div>
+    }
+    else if (CharactersList?.Any() == true)
     {
         <div class="item-grid">
             @foreach (var character in CharactersList)
@@ -33,10 +47,8 @@
     }
     else
     {
-        <div class="d-flex justify-content-center">
-            <div class="control">
-                <MatProgressCircle Indeterminate="true" Size="MatProgressCircleSize.Medium" />
-            </div>
+        <div class="alert alert-info" role="alert">
+            No characters were found for this anime.
         </div>
     }
 

--- a/AnimeCharacters/Pages/AnimeDetails.razor.cs
+++ b/AnimeCharacters/Pages/AnimeDetails.razor.cs
@@ -3,6 +3,7 @@ using AnimeCharacters.Helpers;
 using AnimeCharacters.Models;
 using Kitsu.Models;
 using Microsoft.AspNetCore.Components;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -21,6 +22,10 @@ namespace AnimeCharacters.Pages
         public string Language { get; set; } = "Japanese";
 
         public List<AniListClient.Models.Character> CharactersList { get; set; } = new();
+
+        public bool IsLoadingCharacters { get; set; }
+
+        public string CharacterLoadError { get; set; }
 
         public UserSettings UserSettings { get; set; } = new UserSettings();
 
@@ -57,7 +62,20 @@ namespace AnimeCharacters.Pages
 
             StateHasChanged();
 
-            await _LoadCharacters();
+            IsLoadingCharacters = true;
+            CharacterLoadError = null;
+            try
+            {
+                await _LoadCharacters();
+            }
+            catch (Exception ex)
+            {
+                CharacterLoadError = $"Unable to load characters from AniList. {ex.Message}";
+            }
+            finally
+            {
+                IsLoadingCharacters = false;
+            }
 
             StateHasChanged();
         }
@@ -75,7 +93,11 @@ namespace AnimeCharacters.Pages
         {
             var media = await AnilistClient.Characters.GetMediaWithCharactersById(int.Parse(CurrentAnime.AnilistId));
 
-            if (media == null) { return; }
+            if (media == null)
+            {
+                CharacterLoadError = "AniList did not return character data for this anime.";
+                return;
+            }
 
             var characters = new List<AniListClient.Models.Character>();
 

--- a/AnimeCharacters/Pages/Characters.razor
+++ b/AnimeCharacters/Pages/Characters.razor
@@ -140,7 +140,21 @@
     <h3>Characters from My Anime</h3>
     <hr />
 
-    @if (MyCharactersList?.Any() == true)
+    @if (IsLoadingCharacters)
+    {
+        <div class="d-flex justify-content-center">
+            <div class="control">
+                <MatProgressCircle Indeterminate="true" Size="MatProgressCircleSize.Medium" />
+            </div>
+        </div>
+    }
+    else if (!string.IsNullOrWhiteSpace(CharacterLoadError))
+    {
+        <div class="alert alert-warning" role="alert">
+            @CharacterLoadError
+        </div>
+    }
+    else if (MyCharactersList?.Any() == true)
     {
         <div class="item-grid">
             @foreach (var characterAnime in MyCharactersList)
@@ -152,7 +166,7 @@
         </div>
     }
 
-    @if (NotMyCharactersList?.Any() == true)
+    @if (!IsLoadingCharacters && string.IsNullOrWhiteSpace(CharacterLoadError) && NotMyCharactersList?.Any() == true)
     {
         <div class="item-grid">
             @foreach (var characterAnime in NotMyCharactersList)
@@ -164,12 +178,10 @@
         </div>
     }
 
-    @if (MyCharactersList?.Any() != true && NotMyCharactersList?.Any() != true)
+    @if (!IsLoadingCharacters && string.IsNullOrWhiteSpace(CharacterLoadError) && MyCharactersList?.Any() != true && NotMyCharactersList?.Any() != true)
     {
-        <div class="d-flex justify-content-center">
-            <div class="control">
-                <MatProgressCircle Indeterminate="true" Size="MatProgressCircleSize.Medium" />
-            </div>
+        <div class="alert alert-info" role="alert">
+            No matching characters were found in your anime.
         </div>
     }
 </div>

--- a/AnimeCharacters/Pages/Characters.razor.cs
+++ b/AnimeCharacters/Pages/Characters.razor.cs
@@ -24,6 +24,10 @@ namespace AnimeCharacters.Pages
         public List<CharacterAnimeModel> MyCharactersList { get; set; } = new();
         public List<CharacterAnimeModel> NotMyCharactersList { get; set; } = new();
 
+        public bool IsLoadingCharacters { get; set; }
+
+        public string CharacterLoadError { get; set; }
+
         private bool _showMobileDetails = false;
 
         [Parameter]
@@ -42,7 +46,20 @@ namespace AnimeCharacters.Pages
             }
 
             CurrentUser = await DatabaseProvider.GetUserAsync();
-            CurrentPerson = await _anilistClient.Staff.GetStaffById(int.Parse(Id));
+            IsLoadingCharacters = true;
+            CharacterLoadError = null;
+
+            try
+            {
+                CurrentPerson = await _anilistClient.Staff.GetStaffById(int.Parse(Id));
+            }
+            catch (Exception ex)
+            {
+                CharacterLoadError = $"Unable to load characters from AniList. {ex.Message}";
+                IsLoadingCharacters = false;
+                StateHasChanged();
+                return;
+            }
 
             if (CurrentPerson == null)
             {
@@ -52,7 +69,18 @@ namespace AnimeCharacters.Pages
 
             StateHasChanged();
 
-            await _LoadCharacters();
+            try
+            {
+                await _LoadCharacters();
+            }
+            catch (Exception ex)
+            {
+                CharacterLoadError = $"Unable to load characters from AniList. {ex.Message}";
+            }
+            finally
+            {
+                IsLoadingCharacters = false;
+            }
 
             StateHasChanged();
         }

--- a/Kitsu.Tests/AniListClient/CharactersControllerTests.cs
+++ b/Kitsu.Tests/AniListClient/CharactersControllerTests.cs
@@ -1,0 +1,86 @@
+using AniListClient.Controllers;
+using GraphQL.Client.Http;
+using GraphQL.Client.Serializer.Newtonsoft;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Kitsu.Tests.AniListClient
+{
+    [TestClass]
+    public class CharactersControllerTests
+    {
+        [TestMethod]
+        public async Task GetMediaWithCharactersById_WhenAniListReturnsGraphQLHttpError_ThrowsReadableMessage()
+        {
+            using var graphQLClient = new GraphQLHttpClient(
+                new GraphQLHttpClientOptions
+                {
+                    EndPoint = new Uri("https://graphql.anilist.co"),
+                    HttpMessageHandler = new StubHttpMessageHandler(new HttpResponseMessage(HttpStatusCode.Forbidden)
+                    {
+                        Content = new StringContent("""
+                        {
+                            "errors": [
+                                {
+                                    "message": "The AniList API has been temporarily disabled due to severe stability issues.",
+                                    "status": 403
+                                }
+                            ],
+                            "data": null
+                        }
+                        """)
+                    })
+                },
+                new NewtonsoftJsonSerializer());
+            var controller = new CharactersController(graphQLClient);
+
+            var exception = await Assert.ThrowsExceptionAsync<InvalidOperationException>(
+                () => controller.GetMediaWithCharactersById(123));
+
+            StringAssert.Contains(exception.Message, "temporarily disabled");
+        }
+
+        [TestMethod]
+        public async Task GetMediaWithCharactersById_WhenAniListCannotBeReached_ThrowsReadableMessage()
+        {
+            using var graphQLClient = new GraphQLHttpClient(
+                new GraphQLHttpClientOptions
+                {
+                    EndPoint = new Uri("https://graphql.anilist.co"),
+                    HttpMessageHandler = new StubHttpMessageHandler(new HttpRequestException("Network failure"))
+                },
+                new NewtonsoftJsonSerializer());
+            var controller = new CharactersController(graphQLClient);
+
+            var exception = await Assert.ThrowsExceptionAsync<InvalidOperationException>(
+                () => controller.GetMediaWithCharactersById(123));
+
+            StringAssert.Contains(exception.Message, "Unable to reach AniList");
+        }
+
+        private class StubHttpMessageHandler : HttpMessageHandler
+        {
+            private readonly HttpResponseMessage _response;
+            private readonly Exception _exception;
+
+            public StubHttpMessageHandler(HttpResponseMessage response)
+            {
+                _response = response;
+            }
+
+            public StubHttpMessageHandler(Exception exception)
+            {
+                _exception = exception;
+            }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+                _exception != null
+                    ? Task.FromException<HttpResponseMessage>(_exception)
+                    : Task.FromResult(_response);
+        }
+    }
+}

--- a/Kitsu.Tests/Kitsu.Tests.csproj
+++ b/Kitsu.Tests/Kitsu.Tests.csproj
@@ -8,15 +8,16 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.5.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.5.1" />
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="MSTest.TestAdapter" Version="3.5.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.5.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\AniListClient\AniListClient.csproj" />
     <ProjectReference Include="..\Kitsu\Kitsu.csproj" />
   </ItemGroup>
 

--- a/Kitsu/Kitsu.csproj
+++ b/Kitsu/Kitsu.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
﻿## Summary
- surface AniList HTTP/GraphQL failures as readable errors instead of returning null
- stop anime and voice-actor character pages from showing endless loading spinners after failures or empty results
- update compatible .NET 8 patch packages and add regression coverage for AniList outage/fetch-failure paths

## Verification
- dotnet test
- dotnet build
- dotnet list package --outdated --highest-patch
- dotnet run --no-launch-profile --project AnimeCharacters\AnimeCharacters.csproj --urls http://localhost:5076
- Browser: logged-in /animes -> Witch Hat Atelier (/animes/46043) shows AniList availability warning and 0 progress spinners
- Browser: /characters/95097 shows AniList availability warning and 0 progress spinners

## Notes
AniList is currently returning an API-level outage response: "The AniList API has been temporarily disabled due to severe stability issues." This PR does not replace AniList as the data source; it makes the outage visible and prevents the UI from spinning indefinitely.
