### PR TITLE
Fix anime details for missing AniList mappings

### DIFF
--- a/AniListClient/Controllers/BaseController.cs
+++ b/AniListClient/Controllers/BaseController.cs
@@ -102,7 +102,7 @@ namespace AniListClient.Controllers
             }
         }
 
-        private static string GetGraphQLHttpErrorMessage(GraphQLHttpRequestException ex)
+        protected static string GetGraphQLHttpErrorMessage(GraphQLHttpRequestException ex)
         {
             if (string.IsNullOrWhiteSpace(ex.Content))
             {

--- a/AniListClient/Controllers/CharactersController.cs
+++ b/AniListClient/Controllers/CharactersController.cs
@@ -2,7 +2,11 @@
 using AniListClient.Models;
 using AniListClient.Queries;
 using AniListClient.Responses;
+using GraphQL;
 using GraphQL.Client.Http;
+using System;
+using System.Linq;
+using System.Net.Http;
 using System.Threading.Tasks;
 
 namespace AniListClient.Controllers
@@ -20,5 +24,40 @@ namespace AniListClient.Controllers
                 q => q.Characters,
                 q => q.Media.ToMedia(),
                 q => q.Media.Characters.PageInfo?.HasNextPage ?? false);
+
+        public async Task<MediaBase> SearchMediaByTitle(string title)
+        {
+            if (string.IsNullOrWhiteSpace(title))
+            {
+                return null;
+            }
+
+            var request = new GraphQLRequest(CharactersQueries.SEARCH_ANIME_BY_TITLE_QUERY)
+            {
+                OperationName = CharactersQueries.SEARCH_ANIME_BY_TITLE_NAME,
+                Variables = new SearchAnimeQueryVariable(title)
+            };
+
+            GraphQLResponse<SearchMediaResponse> result;
+            try
+            {
+                result = await _graphQLHttpClient.SendQueryAsync<SearchMediaResponse>(request);
+            }
+            catch (GraphQLHttpRequestException ex)
+            {
+                throw new InvalidOperationException(GetGraphQLHttpErrorMessage(ex), ex);
+            }
+            catch (HttpRequestException ex)
+            {
+                throw new InvalidOperationException("Unable to reach AniList. The API may be unavailable right now.", ex);
+            }
+
+            if (result.Errors?.Length > 0)
+            {
+                throw new InvalidOperationException(result.Errors[0].Message);
+            }
+
+            return result.Data?.Page?.Media?.FirstOrDefault()?.ToMedia();
+        }
     }
 }

--- a/AniListClient/Converters/CharacterResponseConverter.cs
+++ b/AniListClient/Converters/CharacterResponseConverter.cs
@@ -20,6 +20,11 @@ namespace AniListClient.Converters
                 Id: media.Id,
                 Title: media.Title.ToTitle());
 
+        internal static Models.MediaBase ToMedia(this SearchMediaResponse.MediaResponse media) =>
+            new(
+                Id: media.Id,
+                Title: media.Title?.ToTitle());
+
         internal static Models.Character ToCharacter(this CharactersFromAnimeResponse.CharacterEdge characterEdge) =>
             new(
                 Id: characterEdge.Node.Id,

--- a/AniListClient/Queries/CharactersQueries.cs
+++ b/AniListClient/Queries/CharactersQueries.cs
@@ -58,6 +58,23 @@ query getStaffByAnime($anime_id: Int, $page:Int=1) {
     }
   }
 }";
+
+        internal const string SEARCH_ANIME_BY_TITLE_NAME = "searchAnimeByTitle";
+
+        internal const string SEARCH_ANIME_BY_TITLE_QUERY = @"
+query searchAnimeByTitle($search: String) {
+  Page(page: 1, perPage: 1) {
+    media(search: $search, type: ANIME) {
+      id
+      title {
+        romaji
+        english
+        native
+        userPreferred
+      }
+    }
+  }
+}";
     }
 
     internal class CharacterQueryVariable : IHasPage
@@ -74,5 +91,16 @@ query getStaffByAnime($anime_id: Int, $page:Int=1) {
 
         [JsonProperty("anime_id")]
         public int AnimeId { get; set; }
+    }
+
+    internal class SearchAnimeQueryVariable
+    {
+        internal SearchAnimeQueryVariable(string search)
+        {
+            Search = search;
+        }
+
+        [JsonProperty("search")]
+        public string Search { get; set; }
     }
 }

--- a/AniListClient/Responses/SearchMediaResponse.cs
+++ b/AniListClient/Responses/SearchMediaResponse.cs
@@ -1,0 +1,25 @@
+using Newtonsoft.Json;
+
+namespace AniListClient.Responses
+{
+    internal class SearchMediaResponse
+    {
+        [JsonProperty("Page", NullValueHandling = NullValueHandling.Ignore)]
+        public PageResponse Page { get; set; }
+
+        internal class PageResponse
+        {
+            [JsonProperty("media", NullValueHandling = NullValueHandling.Ignore)]
+            public MediaResponse[] Media { get; set; }
+        }
+
+        internal class MediaResponse
+        {
+            [JsonProperty("id")]
+            public int Id { get; set; }
+
+            [JsonProperty("title", NullValueHandling = NullValueHandling.Ignore)]
+            public Title Title { get; set; }
+        }
+    }
+}

--- a/AnimeCharacters/Pages/AnimeDetails.razor.cs
+++ b/AnimeCharacters/Pages/AnimeDetails.razor.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Components;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
 namespace AnimeCharacters.Pages
@@ -46,7 +47,9 @@ namespace AnimeCharacters.Pages
 
             CurrentUser = await DatabaseProvider.GetUserAsync();
             UserSettings = await DatabaseProvider.GetUserSettingsAsync() ?? new UserSettings();
-            CurrentAnime = (await DatabaseProvider.GetLibrariesAsync()).FirstOrDefault(libray => libray.Anime?.KitsuId == Id).Anime;
+            var libraries = await DatabaseProvider.GetLibrariesAsync() ?? new List<LibraryEntry>();
+            var currentLibraryEntry = libraries.FirstOrDefault(library => library.Anime?.KitsuId == Id);
+            CurrentAnime = currentLibraryEntry?.Anime;
 
             if (CurrentAnime == null)
             {
@@ -54,9 +57,10 @@ namespace AnimeCharacters.Pages
                 return;
             }
 
-            if (string.IsNullOrWhiteSpace(CurrentAnime.AnilistId))
+            if (!await _EnsureAniListId(libraries))
             {
-                NavigationManager.NavigateTo("/animes");
+                CharacterLoadError = "AniList has not linked this anime yet, so characters cannot be loaded.";
+                StateHasChanged();
                 return;
             }
 
@@ -120,6 +124,85 @@ namespace AnimeCharacters.Pages
             CharactersList = characters
                 .OrderByDescending(c => c, CharacterByRoleComparer.Instance)
                 .ToList();
+        }
+
+        async Task<bool> _EnsureAniListId(IList<LibraryEntry> libraries)
+        {
+            if (!string.IsNullOrWhiteSpace(CurrentAnime.AnilistId))
+            {
+                return true;
+            }
+
+            var searchTitles = new[]
+            {
+                CurrentAnime.EnglishTitle,
+                CurrentAnime.RomanjiTitle,
+                CurrentAnime.Title,
+                _GetSearchTitleFromSlug(CurrentAnime.KitsuSlug)
+            }
+            .Where(title => !string.IsNullOrWhiteSpace(title))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+            foreach (var title in searchTitles)
+            {
+                var media = await AnilistClient.Characters.SearchMediaByTitle(title);
+
+                if (media == null || !_IsTitleMatch(media.Title, searchTitles))
+                {
+                    continue;
+                }
+
+                CurrentAnime.AnilistId = media.Id.ToString();
+                await DatabaseProvider.SetLibrariesAsync(libraries);
+                return true;
+            }
+
+            return false;
+        }
+
+        static string _GetSearchTitleFromSlug(string slug)
+        {
+            if (string.IsNullOrWhiteSpace(slug))
+            {
+                return null;
+            }
+
+            return Regex.Replace(slug.Replace('-', ' '), @"\s+", " ").Trim();
+        }
+
+        static bool _IsTitleMatch(AniListClient.Models.Titles mediaTitle, IEnumerable<string> searchTitles)
+        {
+            if (mediaTitle == null)
+            {
+                return false;
+            }
+
+            var normalizedSearchTitles = searchTitles
+                .Select(_NormalizeTitle)
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+            var mediaTitles = new[]
+            {
+                mediaTitle.English,
+                mediaTitle.Romaji,
+                mediaTitle.UserPreferred,
+                mediaTitle.Native
+            };
+
+            return mediaTitles
+                .Select(_NormalizeTitle)
+                .Any(title => !string.IsNullOrWhiteSpace(title) && normalizedSearchTitles.Contains(title));
+        }
+
+        static string _NormalizeTitle(string title)
+        {
+            if (string.IsNullOrWhiteSpace(title))
+            {
+                return null;
+            }
+
+            return Regex.Replace(title, @"[^\p{L}\p{N}]+", " ").Trim();
         }
 
         public string GetAnimeTitle()


### PR DESCRIPTION
## Summary
- Add an AniList title-search fallback when a Kitsu library entry has no AniList mapping yet.
- Keep the details page open and show a character-load message instead of bouncing away when no mapping can be resolved.
- Cache the resolved AniList ID back into local library storage after a title match.

## Verification
- dotnet build
- dotnet test
- Browser flow on http://localhost:5010 using username nblew, searched for The Klutzy Class Monitor and the Girl with the Short Skirt, opened /animes/49834, and observed no page or console errors.