### PR TITLE
Add swappable reference API providers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,7 @@ Debug builds prepend the version with `dev-`.
 - **AnimeCharacters/** - Main Blazor WebAssembly application
 - **Kitsu/** - Client library for Kitsu.app API integration
 - **AniListClient/** - GraphQL client for AniList API
+- **ReferenceApis/** - Provider abstraction and implementations for character, anime reference, and seiyuu data
 - **Kitsu.Tests/** - Unit tests for Kitsu client
 
 ### Key Components
@@ -49,14 +50,15 @@ Debug builds prepend the version with `dev-`.
 #### Data Flow
 1. Users authenticate with Kitsu.app to access their anime library
 2. Library data is cached in browser LocalStorage via `DatabaseProvider`
-3. Character/voice actor data is fetched from AniList GraphQL API
-4. Results are cross-referenced to find shared voice actors
+3. Character/voice actor data is fetched through `ReferenceApis` providers
+4. Results are cross-referenced to find shared voice actors using provider-aware anime IDs
 
 #### Main Services
 - `DatabaseProvider` - LocalStorage wrapper with event notifications
 - `PageStateManager` - Navigation state management
 - `KitsuClient` - REST API client for Kitsu.app
 - `AniListClient` - GraphQL client for AniList API
+- `ReferenceAnimeService` - Chooses reference API providers and merges provider IDs for matching
 
 #### Page Architecture
 - All pages inherit from `BasePage` which provides common dependencies
@@ -65,7 +67,8 @@ Debug builds prepend the version with `dev-`.
 
 ### External APIs
 - **Kitsu.app API** - User authentication and anime library data
-- **AniList GraphQL API** - Character and voice actor information
+- **Jikan/MyAnimeList API** - Primary source for character and Japanese voice actor information
+- **AniList GraphQL API** - Fallback source for character and voice actor information
 
 ## Development Notes
 
@@ -76,7 +79,7 @@ The application uses:
 - Polly for retry policies
 - Service worker for PWA capabilities
 
-When working with API clients, note that both Kitsu and AniList have different response structures and require separate model classes in their respective projects.
+When working with API clients, note that Kitsu library data is separate from reference data. Add new character/anime reference providers behind `IReferenceAnimeProvider` and keep route IDs provider-aware so MAL and AniList IDs do not collide.
 
 When changing or adding features, ensure to update the README.md, CLAUDE.md, and AGENTS.md files to keep documentation consistent.
 

--- a/AniListClient/Models/Character.cs
+++ b/AniListClient/Models/Character.cs
@@ -9,7 +9,8 @@ namespace AniListClient.Models
         string Description,
         CharacterRole? Role,
         List<MediaBase> Media,
-        List<VoiceActorSlim> VoiceActors);
+        List<VoiceActorSlim> VoiceActors,
+        string ProviderName = "anilist");
 
     public record Names(
         string Romaji,

--- a/AniListClient/Models/Media.cs
+++ b/AniListClient/Models/Media.cs
@@ -4,7 +4,8 @@ namespace AniListClient.Models
 {
     public record MediaBase(
         int Id,
-        Titles Title);
+        Titles Title,
+        string ProviderName = "anilist");
 
     public record Media(
         int Id,
@@ -12,8 +13,9 @@ namespace AniListClient.Models
         string Description,
         Images Image,
         MediaStatus Status,
-        List<Character> Characters
-    ) : MediaBase(Id, Title);
+        List<Character> Characters,
+        string ProviderName = "anilist"
+    ) : MediaBase(Id, Title, ProviderName);
 
     public enum MediaStatus
     {

--- a/AniListClient/Models/Staff.cs
+++ b/AniListClient/Models/Staff.cs
@@ -12,7 +12,8 @@ namespace AniListClient.Models
         DateOfBirth DateOfBirth,
         string BloodType,
         string SiteUrl,
-        List<Character> Characters);
+        List<Character> Characters,
+        string ProviderName = "anilist");
 
     public record DateOfBirth(
         int? Year,

--- a/AniListClient/Models/VoiceActorSlim.cs
+++ b/AniListClient/Models/VoiceActorSlim.cs
@@ -2,5 +2,7 @@
 {
     public record VoiceActorSlim(
         int Id,
-        Names Name);
+        Names Name,
+        string ProviderName = "anilist",
+        string SiteUrl = null);
 }

--- a/AnimeCharacters.sln
+++ b/AnimeCharacters.sln
@@ -13,6 +13,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{E90B4538
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AniListClient", "AniListClient\AniListClient.csproj", "{7D06720E-7412-4D05-82E3-D2587BF9D076}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ReferenceApis", "ReferenceApis\ReferenceApis.csproj", "{BABE6CEC-2E0B-47CE-B505-4367CD468400}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -35,6 +37,10 @@ Global
 		{7D06720E-7412-4D05-82E3-D2587BF9D076}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7D06720E-7412-4D05-82E3-D2587BF9D076}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7D06720E-7412-4D05-82E3-D2587BF9D076}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BABE6CEC-2E0B-47CE-B505-4367CD468400}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BABE6CEC-2E0B-47CE-B505-4367CD468400}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BABE6CEC-2E0B-47CE-B505-4367CD468400}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BABE6CEC-2E0B-47CE-B505-4367CD468400}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/AnimeCharacters/AnimeCharacters.csproj
+++ b/AnimeCharacters/AnimeCharacters.csproj
@@ -68,6 +68,7 @@
   <ItemGroup>
     <ProjectReference Include="..\AniListClient\AniListClient.csproj" />
     <ProjectReference Include="..\Kitsu\Kitsu.csproj" />
+    <ProjectReference Include="..\ReferenceApis\ReferenceApis.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/AnimeCharacters/Pages/AnimeDetails.razor.cs
+++ b/AnimeCharacters/Pages/AnimeDetails.razor.cs
@@ -3,6 +3,7 @@ using AnimeCharacters.Helpers;
 using AnimeCharacters.Models;
 using Kitsu.Models;
 using Microsoft.AspNetCore.Components;
+using ReferenceApis;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -14,7 +15,7 @@ namespace AnimeCharacters.Pages
     public partial class AnimeDetails
     {
         [Inject]
-        AniListClient.AniListClient AnilistClient { get; set; }
+        IReferenceAnimeService ReferenceAnimeService { get; set; }
 
         public User CurrentUser { get; set; }
 
@@ -57,24 +58,17 @@ namespace AnimeCharacters.Pages
                 return;
             }
 
-            if (!await _EnsureAniListId(libraries))
-            {
-                CharacterLoadError = "AniList has not linked this anime yet, so characters cannot be loaded.";
-                StateHasChanged();
-                return;
-            }
-
             StateHasChanged();
 
             IsLoadingCharacters = true;
             CharacterLoadError = null;
             try
             {
-                await _LoadCharacters();
+                await _LoadCharacters(libraries);
             }
             catch (Exception ex)
             {
-                CharacterLoadError = $"Unable to load characters from AniList. {ex.Message}";
+                CharacterLoadError = $"Unable to load characters from the reference APIs. {ex.Message}";
             }
             finally
             {
@@ -90,18 +84,21 @@ namespace AnimeCharacters.Pages
 
             if (voiceActor == null) { return; }
 
-            NavigationManager.NavigateTo($"/characters/{voiceActor.Id}");
+            NavigationManager.NavigateTo($"/characters/{voiceActor.ProviderName}/{voiceActor.Id}");
         }
 
-        async Task _LoadCharacters()
+        async Task _LoadCharacters(IList<LibraryEntry> libraries)
         {
-            var media = await AnilistClient.Characters.GetMediaWithCharactersById(int.Parse(CurrentAnime.AnilistId));
+            var result = await ReferenceAnimeService.GetMediaWithCharactersAsync(CurrentAnime, _GetSearchTitles());
+            var media = result.Media;
 
             if (media == null)
             {
-                CharacterLoadError = "AniList did not return character data for this anime.";
+                CharacterLoadError = "The reference APIs did not return character data for this anime.";
                 return;
             }
+
+            await _PersistResolvedReferenceId(result, libraries);
 
             var characters = new List<AniListClient.Models.Character>();
 
@@ -126,39 +123,47 @@ namespace AnimeCharacters.Pages
                 .ToList();
         }
 
-        async Task<bool> _EnsureAniListId(IList<LibraryEntry> libraries)
+        async Task _PersistResolvedReferenceId(ReferenceMediaResult result, IList<LibraryEntry> libraries)
         {
-            if (!string.IsNullOrWhiteSpace(CurrentAnime.AnilistId))
+            if (result?.AnimeKey == null)
             {
-                return true;
+                return;
             }
 
-            var searchTitles = new[]
+            var hasChange = false;
+
+            if (ReferenceAnimeKey.MatchesProvider(result.AnimeKey.ProviderName, ReferenceProviderNames.AniList)
+                && string.IsNullOrWhiteSpace(CurrentAnime.AnilistId))
             {
-                CurrentAnime.EnglishTitle,
-                CurrentAnime.RomanjiTitle,
-                CurrentAnime.Title,
-                _GetSearchTitleFromSlug(CurrentAnime.KitsuSlug)
+                CurrentAnime.AnilistId = result.AnimeKey.Id;
+                hasChange = true;
+            }
+
+            if (ReferenceAnimeKey.MatchesProvider(result.AnimeKey.ProviderName, ReferenceProviderNames.Jikan)
+                && string.IsNullOrWhiteSpace(CurrentAnime.MyAnimeListId))
+            {
+                CurrentAnime.MyAnimeListId = result.AnimeKey.Id;
+                hasChange = true;
+            }
+
+            if (hasChange)
+            {
+                await DatabaseProvider.SetLibrariesAsync(libraries);
+            }
+        }
+
+        List<string> _GetSearchTitles()
+        {
+            return new[]
+            {
+                CurrentAnime?.EnglishTitle,
+                CurrentAnime?.RomanjiTitle,
+                CurrentAnime?.Title,
+                _GetSearchTitleFromSlug(CurrentAnime?.KitsuSlug)
             }
             .Where(title => !string.IsNullOrWhiteSpace(title))
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .ToList();
-
-            foreach (var title in searchTitles)
-            {
-                var media = await AnilistClient.Characters.SearchMediaByTitle(title);
-
-                if (media == null || !_IsTitleMatch(media.Title, searchTitles))
-                {
-                    continue;
-                }
-
-                CurrentAnime.AnilistId = media.Id.ToString();
-                await DatabaseProvider.SetLibrariesAsync(libraries);
-                return true;
-            }
-
-            return false;
         }
 
         static string _GetSearchTitleFromSlug(string slug)
@@ -169,40 +174,6 @@ namespace AnimeCharacters.Pages
             }
 
             return Regex.Replace(slug.Replace('-', ' '), @"\s+", " ").Trim();
-        }
-
-        static bool _IsTitleMatch(AniListClient.Models.Titles mediaTitle, IEnumerable<string> searchTitles)
-        {
-            if (mediaTitle == null)
-            {
-                return false;
-            }
-
-            var normalizedSearchTitles = searchTitles
-                .Select(_NormalizeTitle)
-                .ToHashSet(StringComparer.OrdinalIgnoreCase);
-
-            var mediaTitles = new[]
-            {
-                mediaTitle.English,
-                mediaTitle.Romaji,
-                mediaTitle.UserPreferred,
-                mediaTitle.Native
-            };
-
-            return mediaTitles
-                .Select(_NormalizeTitle)
-                .Any(title => !string.IsNullOrWhiteSpace(title) && normalizedSearchTitles.Contains(title));
-        }
-
-        static string _NormalizeTitle(string title)
-        {
-            if (string.IsNullOrWhiteSpace(title))
-            {
-                return null;
-            }
-
-            return Regex.Replace(title, @"[^\p{L}\p{N}]+", " ").Trim();
         }
 
         public string GetAnimeTitle()

--- a/AnimeCharacters/Pages/Characters.razor
+++ b/AnimeCharacters/Pages/Characters.razor
@@ -1,4 +1,5 @@
 ﻿@page "/characters/{id}"
+@page "/characters/{provider}/{id}"
 @inherits BasePage
 
 <div class="content">

--- a/AnimeCharacters/Pages/Characters.razor.cs
+++ b/AnimeCharacters/Pages/Characters.razor.cs
@@ -1,6 +1,7 @@
 ﻿using AnimeCharacters.Models;
 using Kitsu.Models;
 using Microsoft.AspNetCore.Components;
+using ReferenceApis;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -15,7 +16,7 @@ namespace AnimeCharacters.Pages
     public partial class Characters
     {
         [Inject]
-        AniListClient.AniListClient _anilistClient { get; set; }
+        IReferenceAnimeService ReferenceAnimeService { get; set; }
 
         public User CurrentUser { get; set; }
 
@@ -32,6 +33,9 @@ namespace AnimeCharacters.Pages
 
         [Parameter]
         public string Id { get; set; }
+
+        [Parameter]
+        public string Provider { get; set; }
 
         protected override async Task OnAfterRenderAsync(bool firstRender)
         {
@@ -51,11 +55,13 @@ namespace AnimeCharacters.Pages
 
             try
             {
-                CurrentPerson = await _anilistClient.Staff.GetStaffById(int.Parse(Id));
+                CurrentPerson = await ReferenceAnimeService.GetStaffByIdAsync(
+                    string.IsNullOrWhiteSpace(Provider) ? ReferenceProviderNames.AniList : Provider,
+                    Id);
             }
             catch (Exception ex)
             {
-                CharacterLoadError = $"Unable to load characters from AniList. {ex.Message}";
+                CharacterLoadError = $"Unable to load characters from the reference APIs. {ex.Message}";
                 IsLoadingCharacters = false;
                 StateHasChanged();
                 return;
@@ -75,7 +81,7 @@ namespace AnimeCharacters.Pages
             }
             catch (Exception ex)
             {
-                CharacterLoadError = $"Unable to load characters from AniList. {ex.Message}";
+                CharacterLoadError = $"Unable to load characters from the reference APIs. {ex.Message}";
             }
             finally
             {
@@ -98,17 +104,19 @@ namespace AnimeCharacters.Pages
 
         async Task _LoadCharacters()
         {
-            // Key by AniList anime id -> list of characters this VA voiced in that anime
+            // Key by reference API anime id -> list of characters this VA voiced in that anime
             var vaRoles = new Dictionary<string, List<AniListClient.Models.Character>>();
 
-            foreach (var character in CurrentPerson.Characters.Where(role => role.Media != null))
+            foreach (var character in (CurrentPerson.Characters ?? new List<AniListClient.Models.Character>()).Where(role => role.Media != null))
             {
                 foreach (var mediaItem in character.Media)
                 {
-                    if (!vaRoles.TryGetValue(mediaItem.Id.ToString(), out var list))
+                    var animeKey = new ReferenceAnimeKey(mediaItem.ProviderName, mediaItem.Id.ToString()).CacheKey;
+
+                    if (!vaRoles.TryGetValue(animeKey, out var list))
                     {
                         list = new List<AniListClient.Models.Character>();
-                        vaRoles[mediaItem.Id.ToString()] = list;
+                        vaRoles[animeKey] = list;
                     }
 
                     // Preserve order of characters as returned from the API
@@ -116,15 +124,16 @@ namespace AnimeCharacters.Pages
                 }
             }
 
-            var libraryEntries = await DatabaseProvider.GetLibrariesAsync();
+            var libraryEntries = await DatabaseProvider.GetLibrariesAsync() ?? new List<LibraryEntry>();
 
             MyCharactersList =
-                libraryEntries.Where(libraryEntry =>
-                                              !string.IsNullOrWhiteSpace(libraryEntry.Anime.AnilistId) &&
-                                              vaRoles.ContainsKey(libraryEntry.Anime.AnilistId))
+                libraryEntries.Where(libraryEntry => ReferenceAnimeService.GetKnownAnimeKeys(libraryEntry.Anime)
+                                                                           .Any(key => vaRoles.ContainsKey(key.CacheKey)))
                               .SelectMany(libraryEntry =>
                               {
-                                  var characters = vaRoles[libraryEntry.Anime.AnilistId];
+                                  var characters = ReferenceAnimeService.GetKnownAnimeKeys(libraryEntry.Anime)
+                                                                        .Where(key => vaRoles.ContainsKey(key.CacheKey))
+                                                                        .SelectMany(key => vaRoles[key.CacheKey]);
                                   return characters.Select(character => new CharacterAnimeModel
                                   {
                                       KitsuId = libraryEntry.Anime.KitsuId,
@@ -185,18 +194,18 @@ namespace AnimeCharacters.Pages
             var links = new List<SocialMediaLink>();
 
             if (string.IsNullOrWhiteSpace(CurrentPerson?.Description))
-                return links;
+            {
+                if (!string.IsNullOrWhiteSpace(CurrentPerson?.SiteUrl))
+                {
+                    links.Add(CreateReferenceProviderLink());
+                }
 
-            // Add AniList profile link if available
+                return links;
+            }
+
             if (!string.IsNullOrWhiteSpace(CurrentPerson.SiteUrl))
             {
-                links.Add(new SocialMediaLink
-                {
-                    Platform = "AniList",
-                    Url = CurrentPerson.SiteUrl,
-                    DisplayText = "anilist.co",
-                    IconPath = "/images/anilist-icon.svg"
-                });
+                links.Add(CreateReferenceProviderLink());
             }
 
             // Extract markdown links from biography
@@ -216,6 +225,19 @@ namespace AnimeCharacters.Pages
             }
 
             return links;
+        }
+
+        private SocialMediaLink CreateReferenceProviderLink()
+        {
+            var isAniList = ReferenceAnimeKey.MatchesProvider(CurrentPerson.ProviderName, ReferenceProviderNames.AniList);
+
+            return new SocialMediaLink
+            {
+                Platform = isAniList ? "AniList" : "MyAnimeList",
+                Url = CurrentPerson.SiteUrl,
+                DisplayText = ExtractDomain(CurrentPerson.SiteUrl),
+                IconPath = isAniList ? "/images/anilist-icon.svg" : "/images/website-icon.svg"
+            };
         }
 
         private SocialMediaLink CreateSocialMediaLink(string text, string url)

--- a/AnimeCharacters/Program.cs
+++ b/AnimeCharacters/Program.cs
@@ -2,6 +2,7 @@ using Blazored.LocalStorage;
 using MatBlazor;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using Microsoft.Extensions.DependencyInjection;
+using ReferenceApis;
 using System;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -25,6 +26,9 @@ namespace AnimeCharacters
 
             builder.Services.AddScoped<IDatabaseProvider, DatabaseProvider>();
             builder.Services.AddScoped(_ => new AniListClient.AniListClient());
+            builder.Services.AddScoped<IReferenceAnimeProvider, JikanReferenceAnimeProvider>();
+            builder.Services.AddScoped<IReferenceAnimeProvider, AniListReferenceAnimeProvider>();
+            builder.Services.AddScoped<IReferenceAnimeService, ReferenceAnimeService>();
 
             await builder.Build().RunAsync();
         }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,7 @@ Debug builds prepend the version with `dev-`.
 - **AnimeCharacters/** - Main Blazor WebAssembly application
 - **Kitsu/** - Client library for Kitsu.app API integration
 - **AniListClient/** - GraphQL client for AniList API
+- **ReferenceApis/** - Provider abstraction and implementations for character, anime reference, and seiyuu data
 - **Kitsu.Tests/** - Unit tests for Kitsu client
 
 ### Key Components
@@ -49,14 +50,15 @@ Debug builds prepend the version with `dev-`.
 #### Data Flow
 1. Users authenticate with Kitsu.app to access their anime library
 2. Library data is cached in browser LocalStorage via `DatabaseProvider`
-3. Character/voice actor data is fetched from AniList GraphQL API
-4. Results are cross-referenced to find shared voice actors
+3. Character/voice actor data is fetched through `ReferenceApis` providers
+4. Results are cross-referenced to find shared voice actors using provider-aware anime IDs
 
 #### Main Services
 - `DatabaseProvider` - LocalStorage wrapper with event notifications
 - `PageStateManager` - Navigation state management
 - `KitsuClient` - REST API client for Kitsu.app
 - `AniListClient` - GraphQL client for AniList API
+- `ReferenceAnimeService` - Chooses reference API providers and merges provider IDs for matching
 
 #### Page Architecture
 - All pages inherit from `BasePage` which provides common dependencies
@@ -65,7 +67,8 @@ Debug builds prepend the version with `dev-`.
 
 ### External APIs
 - **Kitsu.app API** - User authentication and anime library data
-- **AniList GraphQL API** - Character and voice actor information
+- **Jikan/MyAnimeList API** - Primary source for character and Japanese voice actor information
+- **AniList GraphQL API** - Fallback source for character and voice actor information
 
 ## Development Notes
 
@@ -76,7 +79,7 @@ The application uses:
 - Polly for retry policies
 - Service worker for PWA capabilities
 
-When working with API clients, note that both Kitsu and AniList have different response structures and require separate model classes in their respective projects.
+When working with API clients, note that Kitsu library data is separate from reference data. Add new character/anime reference providers behind `IReferenceAnimeProvider` and keep route IDs provider-aware so MAL and AniList IDs do not collide.
 
 When changing or adding features, ensure to update the README.md, CLAUDE.md, and AGENTS.md files to keep documentation consistent.
 

--- a/Kitsu.Tests/Kitsu.Tests.csproj
+++ b/Kitsu.Tests/Kitsu.Tests.csproj
@@ -19,6 +19,7 @@
   <ItemGroup>
     <ProjectReference Include="..\AniListClient\AniListClient.csproj" />
     <ProjectReference Include="..\Kitsu\Kitsu.csproj" />
+    <ProjectReference Include="..\ReferenceApis\ReferenceApis.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Kitsu.Tests/ReferenceApis/JikanReferenceAnimeProviderTests.cs
+++ b/Kitsu.Tests/ReferenceApis/JikanReferenceAnimeProviderTests.cs
@@ -1,0 +1,150 @@
+using Kitsu.Models;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ReferenceApis;
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Kitsu.Tests.ReferenceApis
+{
+    [TestClass]
+    public class JikanReferenceAnimeProviderTests
+    {
+        [TestMethod]
+        public async Task GetMediaWithCharactersAsync_MapsJapaneseVoiceActorsFromMyAnimeList()
+        {
+            var provider = new JikanReferenceAnimeProvider(new HttpClient(new StubHttpMessageHandler(request =>
+            {
+                Assert.AreEqual("https://api.jikan.moe/v4/anime/1/characters", request.RequestUri.ToString());
+
+                return JsonResponse("""
+                {
+                  "data": [
+                    {
+                      "character": {
+                        "mal_id": 1,
+                        "name": "Spiegel, Spike",
+                        "images": { "jpg": { "image_url": "https://cdn.example/spike.jpg" } }
+                      },
+                      "role": "Main",
+                      "voice_actors": [
+                        {
+                          "person": {
+                            "mal_id": 11,
+                            "url": "https://myanimelist.net/people/11/Kouichi_Yamadera",
+                            "name": "Yamadera, Kouichi"
+                          },
+                          "language": "Japanese"
+                        },
+                        {
+                          "person": {
+                            "mal_id": 12,
+                            "url": "https://myanimelist.net/people/12/Steven_Blum",
+                            "name": "Blum, Steven"
+                          },
+                          "language": "English"
+                        }
+                      ]
+                    }
+                  ]
+                }
+                """);
+            })));
+
+            var anime = new Anime
+            {
+                KitsuId = "cowboy-bebop",
+                MyAnimeListId = "1",
+                Title = "Cowboy Bebop",
+                RomanjiTitle = "Cowboy Bebop",
+                PosterImageUrl = "https://cdn.example/cowboy-bebop.jpg"
+            };
+
+            var result = await provider.GetMediaWithCharactersAsync(anime, new[] { "Cowboy Bebop" });
+
+            Assert.AreEqual(ReferenceProviderNames.Jikan, result.AnimeKey.ProviderName);
+            Assert.AreEqual("1", result.AnimeKey.Id);
+            Assert.AreEqual(ReferenceProviderNames.Jikan, result.Media.ProviderName);
+            Assert.AreEqual("Cowboy Bebop", result.Media.Title.UserPreferred);
+            Assert.AreEqual(1, result.Media.Characters.Count);
+            Assert.AreEqual("Spike Spiegel", result.Media.Characters[0].Name.Full);
+            Assert.AreEqual(ReferenceProviderNames.Jikan, result.Media.Characters[0].ProviderName);
+            Assert.AreEqual(1, result.Media.Characters[0].VoiceActors.Count);
+            Assert.AreEqual(11, result.Media.Characters[0].VoiceActors[0].Id);
+            Assert.AreEqual("Kouichi Yamadera", result.Media.Characters[0].VoiceActors[0].Name.Full);
+            Assert.AreEqual(ReferenceProviderNames.Jikan, result.Media.Characters[0].VoiceActors[0].ProviderName);
+        }
+
+        [TestMethod]
+        public async Task GetStaffByIdAsync_MapsPersonDetailsAndVoiceRoles()
+        {
+            var provider = new JikanReferenceAnimeProvider(new HttpClient(new StubHttpMessageHandler(request =>
+            {
+                Assert.AreEqual("https://api.jikan.moe/v4/people/11/full", request.RequestUri.ToString());
+
+                return JsonResponse("""
+                {
+                  "data": {
+                    "mal_id": 11,
+                    "url": "https://myanimelist.net/people/11/Kouichi_Yamadera",
+                    "images": { "jpg": { "image_url": "https://cdn.example/yamadera.jpg" } },
+                    "name": "Kouichi Yamadera",
+                    "birthday": "1961-06-17T00:00:00+00:00",
+                    "about": "Blood type: A\nBirthplace: Miyagi Prefecture, Japan",
+                    "voices": [
+                      {
+                        "role": "Main",
+                        "anime": {
+                          "mal_id": 1,
+                          "title": "Cowboy Bebop"
+                        },
+                        "character": {
+                          "mal_id": 1,
+                          "name": "Spiegel, Spike",
+                          "images": { "jpg": { "image_url": "https://cdn.example/spike.jpg" } }
+                        }
+                      }
+                    ]
+                  }
+                }
+                """);
+            })));
+
+            var staff = await provider.GetStaffByIdAsync("11");
+
+            Assert.AreEqual(11, staff.Id);
+            Assert.AreEqual("Kouichi Yamadera", staff.Name.Full);
+            Assert.AreEqual(ReferenceProviderNames.Jikan, staff.ProviderName);
+            Assert.AreEqual("A", staff.BloodType);
+            Assert.AreEqual(1961, staff.DateOfBirth.Year);
+            Assert.AreEqual(1, staff.Characters.Count);
+            Assert.AreEqual("Spike Spiegel", staff.Characters[0].Name.Full);
+            Assert.AreEqual(ReferenceProviderNames.Jikan, staff.Characters[0].ProviderName);
+            Assert.AreEqual(1, staff.Characters[0].Media.Count);
+            Assert.AreEqual(1, staff.Characters[0].Media[0].Id);
+            Assert.AreEqual(ReferenceProviderNames.Jikan, staff.Characters[0].Media[0].ProviderName);
+        }
+
+        static HttpResponseMessage JsonResponse(string json) =>
+            new(HttpStatusCode.OK)
+            {
+                Content = new StringContent(json, Encoding.UTF8, "application/json")
+            };
+
+        class StubHttpMessageHandler : HttpMessageHandler
+        {
+            readonly Func<HttpRequestMessage, HttpResponseMessage> _responseFactory;
+
+            public StubHttpMessageHandler(Func<HttpRequestMessage, HttpResponseMessage> responseFactory)
+            {
+                _responseFactory = responseFactory;
+            }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+                Task.FromResult(_responseFactory(request));
+        }
+    }
+}

--- a/Kitsu.Tests/ReferenceApis/ReferenceAnimeServiceTests.cs
+++ b/Kitsu.Tests/ReferenceApis/ReferenceAnimeServiceTests.cs
@@ -1,0 +1,62 @@
+using AniListClient.Models;
+using Kitsu.Models;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ReferenceApis;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Kitsu.Tests.ReferenceApis
+{
+    [TestClass]
+    public class ReferenceAnimeServiceTests
+    {
+        [TestMethod]
+        public void GetKnownAnimeKeys_ReturnsAllProviderKeysForLibraryMatching()
+        {
+            var anime = new Anime
+            {
+                MyAnimeListId = "1",
+                AnilistId = "5"
+            };
+            var service = new ReferenceAnimeService(new IReferenceAnimeProvider[]
+            {
+                new StubProvider(ReferenceProviderNames.Jikan, "Jikan / MyAnimeList", anime => anime.MyAnimeListId),
+                new StubProvider(ReferenceProviderNames.AniList, "AniList", anime => anime.AnilistId)
+            });
+
+            var keys = service.GetKnownAnimeKeys(anime).Select(key => key.CacheKey).ToList();
+
+            CollectionAssert.AreEquivalent(
+                new[] { "jikan:1", "anilist:5" },
+                keys);
+        }
+
+        class StubProvider : IReferenceAnimeProvider
+        {
+            readonly System.Func<Anime, string> _animeIdSelector;
+
+            public StubProvider(string name, string displayName, System.Func<Anime, string> animeIdSelector)
+            {
+                Name = name;
+                DisplayName = displayName;
+                _animeIdSelector = animeIdSelector;
+            }
+
+            public string Name { get; }
+            public string DisplayName { get; }
+
+            public ReferenceAnimeKey GetKnownAnimeKey(Anime anime)
+            {
+                var animeId = _animeIdSelector(anime);
+                return string.IsNullOrWhiteSpace(animeId) ? null : new ReferenceAnimeKey(Name, animeId);
+            }
+
+            public Task<ReferenceMediaResult> GetMediaWithCharactersAsync(Anime anime, IReadOnlyCollection<string> searchTitles) =>
+                Task.FromResult<ReferenceMediaResult>(null);
+
+            public Task<Staff> GetStaffByIdAsync(string id) =>
+                Task.FromResult<Staff>(null);
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ The application generates a version at build time using the format `yyyy-MM-bbbb
 The build number is zero-padded to four digits.
 Debug builds are prefixed with `dev-`.
 
+## Reference Data Providers
+
+Kitsu remains the source for user library data. Character, anime reference, and seiyuu data is loaded through the `ReferenceApis` project so providers can be swapped or combined without changing page logic. Jikan/MyAnimeList is currently registered first because it exposes character and Japanese voice actor data by MAL anime id, while AniList remains available as a fallback provider.
+
 # Contributing
 Contributions would be greatly appreciated. Feel free to create issues as well as forking the repo and creating PRs.
 If you wish to make some major contributions please create an issue and we can evauate making you a contributer.

--- a/ReferenceApis/AniListReferenceAnimeProvider.cs
+++ b/ReferenceApis/AniListReferenceAnimeProvider.cs
@@ -1,0 +1,109 @@
+using AniListClient.Models;
+using Kitsu.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+namespace ReferenceApis
+{
+    public class AniListReferenceAnimeProvider : IReferenceAnimeProvider
+    {
+        readonly AniListClient.AniListClient _aniListClient;
+
+        public AniListReferenceAnimeProvider(AniListClient.AniListClient aniListClient)
+        {
+            _aniListClient = aniListClient;
+        }
+
+        public string Name => ReferenceProviderNames.AniList;
+        public string DisplayName => "AniList";
+
+        public ReferenceAnimeKey GetKnownAnimeKey(Anime anime) =>
+            !string.IsNullOrWhiteSpace(anime?.AnilistId)
+                ? new ReferenceAnimeKey(Name, anime.AnilistId)
+                : null;
+
+        public async Task<ReferenceMediaResult> GetMediaWithCharactersAsync(
+            Anime anime,
+            IReadOnlyCollection<string> searchTitles)
+        {
+            var animeId = anime?.AnilistId;
+
+            if (string.IsNullOrWhiteSpace(animeId))
+            {
+                animeId = await SearchAnimeIdAsync(searchTitles);
+            }
+
+            if (string.IsNullOrWhiteSpace(animeId) || !int.TryParse(animeId, out var id))
+            {
+                throw new ReferenceApiProviderException("AniList does not have a matching anime id.");
+            }
+
+            var media = await _aniListClient.Characters.GetMediaWithCharactersById(id);
+            return new ReferenceMediaResult(new ReferenceAnimeKey(Name, animeId), media);
+        }
+
+        public async Task<Staff> GetStaffByIdAsync(string id)
+        {
+            if (!int.TryParse(id, out var staffId))
+            {
+                throw new ReferenceApiProviderException("AniList staff ids must be numeric.");
+            }
+
+            return await _aniListClient.Staff.GetStaffById(staffId);
+        }
+
+        async Task<string> SearchAnimeIdAsync(IReadOnlyCollection<string> searchTitles)
+        {
+            foreach (var title in searchTitles ?? Array.Empty<string>())
+            {
+                var media = await _aniListClient.Characters.SearchMediaByTitle(title);
+
+                if (media == null || !_IsTitleMatch(media.Title, searchTitles))
+                {
+                    continue;
+                }
+
+                return media.Id.ToString();
+            }
+
+            return null;
+        }
+
+        static bool _IsTitleMatch(Titles mediaTitle, IEnumerable<string> searchTitles)
+        {
+            if (mediaTitle == null)
+            {
+                return false;
+            }
+
+            var normalizedSearchTitles = searchTitles
+                .Select(_NormalizeTitle)
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+            var mediaTitles = new[]
+            {
+                mediaTitle.English,
+                mediaTitle.Romaji,
+                mediaTitle.UserPreferred,
+                mediaTitle.Native
+            };
+
+            return mediaTitles
+                .Select(_NormalizeTitle)
+                .Any(title => !string.IsNullOrWhiteSpace(title) && normalizedSearchTitles.Contains(title));
+        }
+
+        static string _NormalizeTitle(string title)
+        {
+            if (string.IsNullOrWhiteSpace(title))
+            {
+                return null;
+            }
+
+            return Regex.Replace(title, @"[^\p{L}\p{N}]+", " ").Trim();
+        }
+    }
+}

--- a/ReferenceApis/IReferenceAnimeProvider.cs
+++ b/ReferenceApis/IReferenceAnimeProvider.cs
@@ -1,0 +1,21 @@
+using AniListClient.Models;
+using Kitsu.Models;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace ReferenceApis
+{
+    public interface IReferenceAnimeProvider
+    {
+        string Name { get; }
+        string DisplayName { get; }
+
+        ReferenceAnimeKey GetKnownAnimeKey(Anime anime);
+
+        Task<ReferenceMediaResult> GetMediaWithCharactersAsync(
+            Anime anime,
+            IReadOnlyCollection<string> searchTitles);
+
+        Task<Staff> GetStaffByIdAsync(string id);
+    }
+}

--- a/ReferenceApis/IReferenceAnimeService.cs
+++ b/ReferenceApis/IReferenceAnimeService.cs
@@ -1,0 +1,18 @@
+using AniListClient.Models;
+using Kitsu.Models;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace ReferenceApis
+{
+    public interface IReferenceAnimeService
+    {
+        IEnumerable<ReferenceAnimeKey> GetKnownAnimeKeys(Anime anime);
+
+        Task<ReferenceMediaResult> GetMediaWithCharactersAsync(
+            Anime anime,
+            IReadOnlyCollection<string> searchTitles);
+
+        Task<Staff> GetStaffByIdAsync(string providerName, string id);
+    }
+}

--- a/ReferenceApis/JikanReferenceAnimeProvider.cs
+++ b/ReferenceApis/JikanReferenceAnimeProvider.cs
@@ -1,0 +1,415 @@
+using AniListClient.Models;
+using Kitsu.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+namespace ReferenceApis
+{
+    public class JikanReferenceAnimeProvider : IReferenceAnimeProvider
+    {
+        const string _BASE_URL = "https://api.jikan.moe/v4/";
+        readonly HttpClient _httpClient;
+
+        public JikanReferenceAnimeProvider(HttpClient httpClient)
+        {
+            _httpClient = httpClient;
+        }
+
+        public string Name => ReferenceProviderNames.Jikan;
+        public string DisplayName => "Jikan / MyAnimeList";
+
+        public ReferenceAnimeKey GetKnownAnimeKey(Anime anime) =>
+            !string.IsNullOrWhiteSpace(anime?.MyAnimeListId)
+                ? new ReferenceAnimeKey(Name, anime.MyAnimeListId)
+                : null;
+
+        public async Task<ReferenceMediaResult> GetMediaWithCharactersAsync(
+            Anime anime,
+            IReadOnlyCollection<string> searchTitles)
+        {
+            var animeId = anime?.MyAnimeListId;
+
+            if (string.IsNullOrWhiteSpace(animeId))
+            {
+                animeId = await SearchAnimeIdAsync(searchTitles);
+            }
+
+            if (string.IsNullOrWhiteSpace(animeId) || !int.TryParse(animeId, out var id))
+            {
+                throw new ReferenceApiProviderException("MyAnimeList does not have a matching anime id.");
+            }
+
+            var response = await GetFromJsonAsync<JikanDataResponse<List<JikanAnimeCharacterEntry>>>(
+                $"anime/{id}/characters");
+
+            var characters = response?.Data?
+                .Select(ToCharacter)
+                .Where(character => character != null)
+                .ToList() ?? new List<Character>();
+
+            return new ReferenceMediaResult(
+                new ReferenceAnimeKey(Name, animeId),
+                new Media(
+                    Id: id,
+                    Title: ToTitles(anime),
+                    Description: null,
+                    Image: ToImages(anime?.PosterImageUrl),
+                    Status: MediaStatus.Finished,
+                    Characters: characters,
+                    ProviderName: Name));
+        }
+
+        public async Task<Staff> GetStaffByIdAsync(string id)
+        {
+            if (!int.TryParse(id, out var staffId))
+            {
+                throw new ReferenceApiProviderException("MyAnimeList person ids must be numeric.");
+            }
+
+            var response = await GetFromJsonAsync<JikanDataResponse<JikanPerson>>($"people/{staffId}/full");
+            var person = response?.Data;
+
+            if (person == null)
+            {
+                throw new ReferenceApiProviderException("MyAnimeList did not return person data.");
+            }
+
+            return new Staff(
+                Id: person.MalId,
+                Name: ToNames(person.Name),
+                Language: Language.Japanese,
+                Images: ToImages(person.Images?.Jpg?.ImageUrl),
+                Description: person.About,
+                Age: null,
+                DateOfBirth: ToDateOfBirth(person.Birthday),
+                BloodType: ExtractBloodType(person.About),
+                SiteUrl: person.Url,
+                Characters: person.Voices?.Select(ToCharacter).Where(character => character != null).ToList() ?? new List<Character>(),
+                ProviderName: Name);
+        }
+
+        async Task<string> SearchAnimeIdAsync(IReadOnlyCollection<string> searchTitles)
+        {
+            foreach (var title in searchTitles ?? Array.Empty<string>())
+            {
+                var response = await GetFromJsonAsync<JikanDataResponse<List<JikanAnimeSearchResult>>>(
+                    $"anime?q={Uri.EscapeDataString(title)}&limit=5");
+
+                var match = response?.Data?.FirstOrDefault(result => _IsTitleMatch(result, searchTitles));
+                if (match != null)
+                {
+                    return match.MalId.ToString();
+                }
+            }
+
+            return null;
+        }
+
+        async Task<T> GetFromJsonAsync<T>(string relativeUrl)
+        {
+            try
+            {
+                return await _httpClient.GetFromJsonAsync<T>(new Uri(new Uri(_BASE_URL), relativeUrl));
+            }
+            catch (HttpRequestException ex)
+            {
+                throw new ReferenceApiProviderException("Jikan could not be reached.", ex);
+            }
+            catch (TaskCanceledException ex)
+            {
+                throw new ReferenceApiProviderException("Jikan request timed out.", ex);
+            }
+        }
+
+        Character ToCharacter(JikanAnimeCharacterEntry entry)
+        {
+            if (entry?.Character == null)
+            {
+                return null;
+            }
+
+            var voiceActors = entry.VoiceActors?
+                .Where(voiceActor => string.Equals(voiceActor.Language, "Japanese", StringComparison.OrdinalIgnoreCase))
+                .Select(ToVoiceActorSlim)
+                .Where(voiceActor => voiceActor != null)
+                .ToList() ?? new List<VoiceActorSlim>();
+
+            return new Character(
+                Id: entry.Character.MalId,
+                Name: ToNames(entry.Character.Name),
+                Image: ToImages(entry.Character.Images?.Jpg?.ImageUrl),
+                Description: null,
+                Role: ToCharacterRole(entry.Role),
+                Media: null,
+                VoiceActors: voiceActors,
+                ProviderName: Name);
+        }
+
+        Character ToCharacter(JikanPersonVoice entry)
+        {
+            if (entry?.Character == null || entry.Anime == null)
+            {
+                return null;
+            }
+
+            return new Character(
+                Id: entry.Character.MalId,
+                Name: ToNames(entry.Character.Name),
+                Image: ToImages(entry.Character.Images?.Jpg?.ImageUrl),
+                Description: null,
+                Role: ToCharacterRole(entry.Role),
+                Media: new List<MediaBase>
+                {
+                    new MediaBase(
+                        Id: entry.Anime.MalId,
+                        Title: ToTitles(entry.Anime.Title),
+                        ProviderName: Name)
+                },
+                VoiceActors: null,
+                ProviderName: Name);
+        }
+
+        VoiceActorSlim ToVoiceActorSlim(JikanVoiceActor voiceActor)
+        {
+            if (voiceActor?.Person == null)
+            {
+                return null;
+            }
+
+            return new VoiceActorSlim(
+                Id: voiceActor.Person.MalId,
+                Name: ToNames(voiceActor.Person.Name),
+                ProviderName: Name,
+                SiteUrl: voiceActor.Person.Url);
+        }
+
+        static CharacterRole? ToCharacterRole(string role) =>
+            role?.Trim().ToLowerInvariant() switch
+            {
+                "main" => CharacterRole.Main,
+                "supporting" => CharacterRole.Supporting,
+                "background" => CharacterRole.Background,
+                _ => null
+            };
+
+        static Names ToNames(string name)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                return new Names(null, null, null, null, null, null, null);
+            }
+
+            var trimmedName = name.Trim();
+            var first = trimmedName;
+            string last = null;
+
+            if (trimmedName.Contains(','))
+            {
+                var parts = trimmedName.Split(',', 2, StringSplitOptions.TrimEntries);
+                last = parts[0];
+                first = parts.Length > 1 ? parts[1] : null;
+                trimmedName = string.Join(" ", new[] { first, last }.Where(part => !string.IsNullOrWhiteSpace(part)));
+            }
+
+            return new Names(
+                Romaji: trimmedName,
+                First: first,
+                Last: last,
+                Full: trimmedName,
+                Native: null,
+                Alternative: null,
+                AlternativeSpoiler: null);
+        }
+
+        static Titles ToTitles(Anime anime) =>
+            new Titles(
+                Romaji: anime?.RomanjiTitle ?? anime?.Title,
+                English: anime?.EnglishTitle,
+                Native: null,
+                UserPreferred: anime?.Title ?? anime?.RomanjiTitle ?? anime?.EnglishTitle);
+
+        static Titles ToTitles(string title) =>
+            new Titles(
+                Romaji: title,
+                English: title,
+                Native: null,
+                UserPreferred: title);
+
+        static Images ToImages(string imageUrl) =>
+            new Images(
+                Medium: imageUrl,
+                Large: imageUrl,
+                ExtraLarge: imageUrl,
+                Color: null);
+
+        static DateOfBirth ToDateOfBirth(string birthday)
+        {
+            if (!DateTimeOffset.TryParse(birthday, out var date))
+            {
+                return null;
+            }
+
+            return new DateOfBirth(date.Year, date.Month, date.Day);
+        }
+
+        static string ExtractBloodType(string about)
+        {
+            if (string.IsNullOrWhiteSpace(about))
+            {
+                return null;
+            }
+
+            var match = Regex.Match(about, @"Blood\s+type:\s*(?<blood>[^\r\n]+)", RegexOptions.IgnoreCase);
+            return match.Success ? match.Groups["blood"].Value.Trim() : null;
+        }
+
+        static bool _IsTitleMatch(JikanAnimeSearchResult result, IEnumerable<string> searchTitles)
+        {
+            var normalizedSearchTitles = searchTitles
+                .Select(_NormalizeTitle)
+                .Where(title => !string.IsNullOrWhiteSpace(title))
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+            var candidateTitles = new[]
+            {
+                result.Title,
+                result.TitleEnglish,
+                result.TitleJapanese
+            }.Concat(result.TitleSynonyms ?? Array.Empty<string>());
+
+            return candidateTitles
+                .Select(_NormalizeTitle)
+                .Any(title => !string.IsNullOrWhiteSpace(title) && normalizedSearchTitles.Contains(title));
+        }
+
+        static string _NormalizeTitle(string title)
+        {
+            if (string.IsNullOrWhiteSpace(title))
+            {
+                return null;
+            }
+
+            return Regex.Replace(title, @"[^\p{L}\p{N}]+", " ").Trim();
+        }
+
+        class JikanDataResponse<T>
+        {
+            [JsonPropertyName("data")]
+            public T Data { get; set; }
+        }
+
+        class JikanAnimeCharacterEntry
+        {
+            [JsonPropertyName("character")]
+            public JikanResource Character { get; set; }
+
+            [JsonPropertyName("role")]
+            public string Role { get; set; }
+
+            [JsonPropertyName("voice_actors")]
+            public List<JikanVoiceActor> VoiceActors { get; set; }
+        }
+
+        class JikanVoiceActor
+        {
+            [JsonPropertyName("person")]
+            public JikanResource Person { get; set; }
+
+            [JsonPropertyName("language")]
+            public string Language { get; set; }
+        }
+
+        class JikanPerson
+        {
+            [JsonPropertyName("mal_id")]
+            public int MalId { get; set; }
+
+            [JsonPropertyName("url")]
+            public string Url { get; set; }
+
+            [JsonPropertyName("images")]
+            public JikanImages Images { get; set; }
+
+            [JsonPropertyName("name")]
+            public string Name { get; set; }
+
+            [JsonPropertyName("about")]
+            public string About { get; set; }
+
+            [JsonPropertyName("birthday")]
+            public string Birthday { get; set; }
+
+            [JsonPropertyName("voices")]
+            public List<JikanPersonVoice> Voices { get; set; }
+        }
+
+        class JikanPersonVoice
+        {
+            [JsonPropertyName("role")]
+            public string Role { get; set; }
+
+            [JsonPropertyName("anime")]
+            public JikanResource Anime { get; set; }
+
+            [JsonPropertyName("character")]
+            public JikanResource Character { get; set; }
+        }
+
+        class JikanAnimeSearchResult
+        {
+            [JsonPropertyName("mal_id")]
+            public int MalId { get; set; }
+
+            [JsonPropertyName("title")]
+            public string Title { get; set; }
+
+            [JsonPropertyName("title_english")]
+            public string TitleEnglish { get; set; }
+
+            [JsonPropertyName("title_japanese")]
+            public string TitleJapanese { get; set; }
+
+            [JsonPropertyName("title_synonyms")]
+            public string[] TitleSynonyms { get; set; }
+        }
+
+        class JikanResource
+        {
+            [JsonPropertyName("mal_id")]
+            public int MalId { get; set; }
+
+            [JsonPropertyName("url")]
+            public string Url { get; set; }
+
+            [JsonPropertyName("images")]
+            public JikanImages Images { get; set; }
+
+            [JsonPropertyName("name")]
+            public string Name { get; set; }
+
+            [JsonPropertyName("title")]
+            public string Title { get; set; }
+        }
+
+        class JikanImages
+        {
+            [JsonPropertyName("jpg")]
+            public JikanJpgImage Jpg { get; set; }
+        }
+
+        class JikanJpgImage
+        {
+            [JsonPropertyName("image_url")]
+            public string ImageUrl { get; set; }
+
+            [JsonPropertyName("large_image_url")]
+            public string LargeImageUrl { get; set; }
+        }
+    }
+}

--- a/ReferenceApis/ReferenceAnimeKey.cs
+++ b/ReferenceApis/ReferenceAnimeKey.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace ReferenceApis
+{
+    public sealed record ReferenceAnimeKey(string ProviderName, string Id)
+    {
+        public string CacheKey => $"{NormalizeProviderName(ProviderName)}:{Id}";
+
+        public static string NormalizeProviderName(string providerName) =>
+            providerName?.Trim().ToLowerInvariant() ?? string.Empty;
+
+        public static bool MatchesProvider(string providerName, string expectedProviderName) =>
+            string.Equals(
+                NormalizeProviderName(providerName),
+                NormalizeProviderName(expectedProviderName),
+                StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/ReferenceApis/ReferenceAnimeService.cs
+++ b/ReferenceApis/ReferenceAnimeService.cs
@@ -1,0 +1,100 @@
+using AniListClient.Models;
+using Kitsu.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace ReferenceApis
+{
+    public class ReferenceAnimeService : IReferenceAnimeService
+    {
+        readonly IReadOnlyList<IReferenceAnimeProvider> _providers;
+        readonly Dictionary<string, ReferenceMediaResult> _mediaCache = new();
+        readonly Dictionary<string, Staff> _staffCache = new();
+
+        public ReferenceAnimeService(IEnumerable<IReferenceAnimeProvider> providers)
+        {
+            _providers = providers?.ToList() ?? new List<IReferenceAnimeProvider>();
+        }
+
+        public IEnumerable<ReferenceAnimeKey> GetKnownAnimeKeys(Anime anime) =>
+            _providers
+                .Select(provider => provider.GetKnownAnimeKey(anime))
+                .Where(key => key != null)
+                .GroupBy(key => key.CacheKey)
+                .Select(group => group.First());
+
+        public async Task<ReferenceMediaResult> GetMediaWithCharactersAsync(
+            Anime anime,
+            IReadOnlyCollection<string> searchTitles)
+        {
+            if (anime == null)
+            {
+                throw new ArgumentNullException(nameof(anime));
+            }
+
+            var failures = new List<string>();
+
+            foreach (var provider in _providers)
+            {
+                var knownKey = provider.GetKnownAnimeKey(anime);
+                if (knownKey != null && _mediaCache.TryGetValue(knownKey.CacheKey, out var cachedMedia))
+                {
+                    return cachedMedia;
+                }
+
+                try
+                {
+                    var result = await provider.GetMediaWithCharactersAsync(anime, searchTitles);
+
+                    if (result?.Media == null)
+                    {
+                        failures.Add($"{provider.DisplayName} did not return media data.");
+                        continue;
+                    }
+
+                    _mediaCache[result.AnimeKey.CacheKey] = result;
+                    return result;
+                }
+                catch (Exception ex) when (ex is ReferenceApiProviderException || ex is HttpRequestException || ex is InvalidOperationException || ex is TaskCanceledException)
+                {
+                    failures.Add($"{provider.DisplayName}: {ex.Message}");
+                }
+            }
+
+            var details = failures.Any()
+                ? $" Tried {string.Join(" ", failures)}"
+                : " No reference API providers are configured.";
+
+            throw new InvalidOperationException($"Unable to load character reference data.{details}");
+        }
+
+        public async Task<Staff> GetStaffByIdAsync(string providerName, string id)
+        {
+            if (string.IsNullOrWhiteSpace(id))
+            {
+                throw new ArgumentException("A staff id is required.", nameof(id));
+            }
+
+            var provider = _providers.FirstOrDefault(provider =>
+                ReferenceAnimeKey.MatchesProvider(provider.Name, providerName));
+
+            if (provider == null)
+            {
+                throw new InvalidOperationException($"Unknown reference API provider '{providerName}'.");
+            }
+
+            var cacheKey = $"{ReferenceAnimeKey.NormalizeProviderName(provider.Name)}:{id}";
+            if (_staffCache.TryGetValue(cacheKey, out var cachedStaff))
+            {
+                return cachedStaff;
+            }
+
+            var staff = await provider.GetStaffByIdAsync(id);
+            _staffCache[cacheKey] = staff;
+            return staff;
+        }
+    }
+}

--- a/ReferenceApis/ReferenceApiProviderException.cs
+++ b/ReferenceApis/ReferenceApiProviderException.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace ReferenceApis
+{
+    public class ReferenceApiProviderException : Exception
+    {
+        public ReferenceApiProviderException(string message)
+            : base(message) { }
+
+        public ReferenceApiProviderException(string message, Exception innerException)
+            : base(message, innerException) { }
+    }
+}

--- a/ReferenceApis/ReferenceApis.csproj
+++ b/ReferenceApis/ReferenceApis.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\AniListClient\AniListClient.csproj" />
+    <ProjectReference Include="..\Kitsu\Kitsu.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/ReferenceApis/ReferenceMediaResult.cs
+++ b/ReferenceApis/ReferenceMediaResult.cs
@@ -1,0 +1,8 @@
+using AniListClient.Models;
+
+namespace ReferenceApis
+{
+    public sealed record ReferenceMediaResult(
+        ReferenceAnimeKey AnimeKey,
+        Media Media);
+}

--- a/ReferenceApis/ReferenceProviderNames.cs
+++ b/ReferenceApis/ReferenceProviderNames.cs
@@ -1,0 +1,8 @@
+namespace ReferenceApis
+{
+    public static class ReferenceProviderNames
+    {
+        public const string AniList = "anilist";
+        public const string Jikan = "jikan";
+    }
+}

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "8.0.319",
+    "rollForward": "latestFeature"
+  }
+}


### PR DESCRIPTION
## Summary
- Add a `ReferenceApis` provider layer so character/anime/seiyuu reference data is no longer hard-wired to AniList.
- Add Jikan/MyAnimeList as the primary reference provider while keeping AniList registered as a fallback provider.
- Make character routes provider-aware (`/characters/{provider}/{id}`) and match watched-anime roles with provider-specific anime keys so MAL and AniList IDs do not collide.
- Update docs and add tests for Jikan mapping plus merged provider keys.

## Research notes
- Jikan documents anime character/staff parsing from MAL character pages and exposes person/voice-role data, which covers the Japanese seiyuu flow this app needs: https://docs.jikan.moe/usage/anime/characters-and-staff/
- AniList remains supported as a provider because its API is designed for character/staff data, but it is no longer the only runtime path: https://anilist.gitbook.io/anilist-apiv2-docs
- MAL official v2 docs were reviewed, but the published reference is not the best fit for this client-side fallback because it is auth-based and did not provide the complete character/voice-role surface this feature needs: https://myanimelist.net/apiconfig/references/api/v2

## Verification
- `dotnet test`
- `dotnet build -c Release`
  - Build succeeds with the existing WASM SQLite native-reference warning.
- Manual browser test with Kitsu slug `nblewtest`: opened the library, loaded Death Note character data via Jikan, then opened Kappei Yamaguchi at `/characters/jikan/67` and confirmed matching watched-anime roles rendered.